### PR TITLE
fix(indicators): resolve transparent icon ghosting on state change

### DIFF
--- a/volumio_peppymeter/volumio_basic.py
+++ b/volumio_peppymeter/volumio_basic.py
@@ -959,8 +959,11 @@ class BasicHandler:
                 self.album_scroller.capture_backing(self.screen)
                 self.album_scroller.set_background_surface(self.bgr_surface)
         
-        # Capture backing for indicators (indicators use skip_restore=True)
+        # Capture backing for indicators (indicators use skip_restore=True in basic handler,
+        # but set_background_surfaces is still needed for proper transparent icon handling)
         if self.indicator_renderer and self.indicator_renderer.has_indicators():
+            if self.bgr_surface:
+                self.indicator_renderer.set_background_surfaces(self.bgr_surface)
             self.indicator_renderer.capture_backings(self.screen)
         
         # Now run meter to show initial needle positions

--- a/volumio_peppymeter/volumio_turntable.py
+++ b/volumio_peppymeter/volumio_turntable.py
@@ -2046,6 +2046,7 @@ class TurntableHandler:
             # LAYER COMPOSITION: Indicators capture backing from bgr_surface (pure static bg)
             # This ensures restore_backing doesn't restore stale meter/tonearm positions
             if self.indicator_renderer and self.indicator_renderer.has_indicators():
+                self.indicator_renderer.set_background_surfaces(self.bgr_surface)
                 self.indicator_renderer.capture_backings(self.bgr_surface)
         else:
             # Fallback to old backing capture if no bgr_surface


### PR DESCRIPTION
When icon indicators (play/pause/etc) have transparent areas, switching states left artifacts from the previous icon visible underneath. This occurred because restore_backing() was using a captured backing that already contained the old icon.

- Add bgr_surface support to IconIndicator for clean background restore
- Pass bgr_surface to indicators in cassette, turntable, and basic handlers
- Change cassette handler to skip_restore=False for proper clearing
- Transparent icon areas now properly reveal clean background on state change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized rendering/backing-restore change affecting only indicator drawing/clearing behavior; minimal impact outside UI visuals.
> 
> **Overview**
> Fixes indicator icon “ghosting” when switching states by restoring indicator regions from a clean pre-icon background (`bgr_surface`) instead of a captured backing that could already contain the previous icon.
> 
> This adds `bgr_surface` support to `IconIndicator` (`set_background_surface` + updated `restore_backing`) and plumbs it through `IndicatorRenderer.set_background_surfaces()` and the `basic`, `cassette`, and `turntable` handlers; `CassetteHandler` also stops using `skip_restore=True` so transparent areas are properly cleared on each state change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5659a6e1ca88972d9ac89713220470577476abb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->