### PR TITLE
feat(remote): add remote display support with spectrum broadcasting

### DIFF
--- a/UIConfig.json
+++ b/UIConfig.json
@@ -1012,7 +1012,8 @@
                                       "remoteServerEnabled",
                                       "remoteServerMode",
                                       "remoteServerPort",
-                                      "remoteDiscoveryPort"
+                                      "remoteDiscoveryPort",
+                                      "remoteSpectrumPort"
                                       ]
                               },
                 "content": [
@@ -1064,6 +1065,21 @@
                                              {"max": 65535}
                                            ],
                              "value": 5579
+                            },
+                            {
+                             "id": "remoteSpectrumPort",
+                             "element": "input",
+                             "type": "number",
+                             "visibleIf": {"field": "remoteServerEnabled", "value": true},
+                             "doc": "TRANSLATE.PEPPY_SCREENSAVER.REMOTE_SPECTRUM_PORT_DOC",
+                             "label": "TRANSLATE.PEPPY_SCREENSAVER.REMOTE_SPECTRUM_PORT",
+                             "attributes": [
+                                             {"placeholder": 5581},
+                                             {"maxlength": 5},
+                                             {"min": 1024},
+                                             {"max": 65535}
+                                           ],
+                             "value": 5581
                             }
                             ]
                 }

--- a/config.json
+++ b/config.json
@@ -62,5 +62,9 @@
   "remoteDiscoveryPort": {
     "value": 5579,
     "type": "number"
+  },
+  "remoteSpectrumPort": {
+    "value": 5581,
+    "type": "number"
   }
 }

--- a/i18n/strings_de.json
+++ b/i18n/strings_de.json
@@ -215,6 +215,8 @@
     "REMOTE_SERVER_PORT":"Pegel-Daten-Port",
     "REMOTE_SERVER_PORT_DOC":"UDP-Port zum Streamen von Audio-Pegeldaten an Remote-Anzeigen.<br /><br /><b>Standard: 5580</b><br /><br />Ändern, wenn dieser Port mit anderen Diensten kollidiert.",
     "REMOTE_DISCOVERY_PORT":"Erkennungs-Port",
-    "REMOTE_DISCOVERY_PORT_DOC":"UDP-Port für Auto-Erkennungs-Broadcasts.<br /><br /><b>Standard: 5579</b><br /><br />Remote-Clients hören auf diesem Port, um den Server automatisch zu finden."
+    "REMOTE_DISCOVERY_PORT_DOC":"UDP-Port für Auto-Erkennungs-Broadcasts.<br /><br /><b>Standard: 5579</b><br /><br />Remote-Clients hören auf diesem Port, um den Server automatisch zu finden.",
+    "REMOTE_SPECTRUM_PORT":"Spektrum-Port",
+    "REMOTE_SPECTRUM_PORT_DOC":"UDP-Port zum Streamen von Spektrumanalysator-Daten an Remote-Anzeigen.<br /><br /><b>Standard: 5581</b><br /><br />Ändern, wenn dieser Port mit anderen Diensten kollidiert."
   }
 }

--- a/i18n/strings_en.json
+++ b/i18n/strings_en.json
@@ -217,6 +217,8 @@
     "REMOTE_SERVER_PORT":"Level data port",
     "REMOTE_SERVER_PORT_DOC":"UDP port for streaming audio level data to remote displays.<br /><br /><b>Default: 5580</b><br /><br />Change if this port conflicts with other services.",
     "REMOTE_DISCOVERY_PORT":"Discovery port",
-    "REMOTE_DISCOVERY_PORT_DOC":"UDP port for auto-discovery broadcasts.<br /><br /><b>Default: 5579</b><br /><br />Remote clients listen on this port to find the server automatically."
+    "REMOTE_DISCOVERY_PORT_DOC":"UDP port for auto-discovery broadcasts.<br /><br /><b>Default: 5579</b><br /><br />Remote clients listen on this port to find the server automatically.",
+    "REMOTE_SPECTRUM_PORT":"Spectrum port",
+    "REMOTE_SPECTRUM_PORT_DOC":"UDP port for streaming spectrum analyzer data to remote displays.<br /><br /><b>Default: 5581</b><br /><br />Change if this port conflicts with other services."
   }
 }

--- a/i18n/strings_fr.json
+++ b/i18n/strings_fr.json
@@ -215,6 +215,8 @@
     "REMOTE_SERVER_PORT":"Port données de niveau",
     "REMOTE_SERVER_PORT_DOC":"Port UDP pour diffuser les données de niveau audio vers les affichages distants.<br /><br /><b>Par défaut: 5580</b><br /><br />Modifier si ce port entre en conflit avec d'autres services.",
     "REMOTE_DISCOVERY_PORT":"Port de découverte",
-    "REMOTE_DISCOVERY_PORT_DOC":"Port UDP pour les diffusions de découverte automatique.<br /><br /><b>Par défaut: 5579</b><br /><br />Les clients distants écoutent sur ce port pour trouver automatiquement le serveur."
+    "REMOTE_DISCOVERY_PORT_DOC":"Port UDP pour les diffusions de découverte automatique.<br /><br /><b>Par défaut: 5579</b><br /><br />Les clients distants écoutent sur ce port pour trouver automatiquement le serveur.",
+    "REMOTE_SPECTRUM_PORT":"Port spectre",
+    "REMOTE_SPECTRUM_PORT_DOC":"Port UDP pour diffuser les données de l'analyseur de spectre vers les affichages distants.<br /><br /><b>Par défaut: 5581</b><br /><br />Modifier si ce port entre en conflit avec d'autres services."
   }
 }

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ peppyScreensaver.prototype.onStart = function() {
             self.config.set('remoteServerMode', peppy_config.current['remote.server.mode'] || 'server_local');
             self.config.set('remoteServerPort', parseInt(peppy_config.current['remote.server.port'], 10) || 5580);
             self.config.set('remoteDiscoveryPort', parseInt(peppy_config.current['remote.discovery.port'], 10) || 5579);
+            self.config.set('remoteSpectrumPort', parseInt(peppy_config.current['remote.spectrum.port'], 10) || 5581);
         }
     }
 
@@ -901,6 +902,13 @@ peppyScreensaver.prototype.getUIConfig = function() {
                 remoteDiscoveryPort = peppy_config && peppy_config.current ? (parseInt(peppy_config.current['remote.discovery.port'], 10) || 5579) : 5579;
             }
             uiconf.sections[9].content[3].value = remoteDiscoveryPort;
+            
+            // spectrum port
+            var remoteSpectrumPort = self.config.get('remoteSpectrumPort');
+            if (remoteSpectrumPort === undefined) {
+                remoteSpectrumPort = peppy_config && peppy_config.current ? (parseInt(peppy_config.current['remote.spectrum.port'], 10) || 5581) : 5581;
+            }
+            uiconf.sections[9].content[4].value = remoteSpectrumPort;
             
         } else {
             self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('PEPPY_SCREENSAVER.PLUGIN_NAME'), self.commandRouter.getI18nString('PEPPY_SCREENSAVER.NO_PEPPYCONFIG'));            
@@ -1727,6 +1735,12 @@ peppyScreensaver.prototype.saveRemoteConf = function (confData) {
       noChanges = false;
   }
   
+  var remoteSpectrumPort = self.minmax('remote_spectrum_port', confData.remoteSpectrumPort, [1024, 65535, 5581]);
+  if (self.config.get('remoteSpectrumPort') !== remoteSpectrumPort) {
+      self.config.set('remoteSpectrumPort', remoteSpectrumPort);
+      noChanges = false;
+  }
+  
   // Also update config.txt for Python/runtime
   if (fs.existsSync(PeppyConf)){
     var remoteServerEnabledStr = remoteServerEnabled ? 'true' : 'false';
@@ -1741,6 +1755,9 @@ peppyScreensaver.prototype.saveRemoteConf = function (confData) {
     }
     if (peppy_config.current['remote.discovery.port'] != remoteDiscoveryPort) {
         peppy_config.current['remote.discovery.port'] = remoteDiscoveryPort;
+    }
+    if (peppy_config.current['remote.spectrum.port'] != remoteSpectrumPort) {
+        peppy_config.current['remote.spectrum.port'] = remoteSpectrumPort;
     }
     
     if (!noChanges) {

--- a/volumio_peppymeter/volumio_configfileparser.py
+++ b/volumio_peppymeter/volumio_configfileparser.py
@@ -260,6 +260,7 @@ REMOTE_SERVER_ENABLED = "remote.server.enabled"     # true/false - enable remote
 REMOTE_SERVER_MODE = "remote.server.mode"           # 'server', 'server_local'
 REMOTE_SERVER_PORT = "remote.server.port"           # UDP port for level data (default 5580)
 REMOTE_DISCOVERY_PORT = "remote.discovery.port"     # UDP port for discovery (default 5579)
+REMOTE_SPECTRUM_PORT = "remote.spectrum.port"       # UDP port for spectrum data (default 5581)
 
 class Volumio_ConfigFileParser(object):
     """ Configuration file parser """
@@ -411,6 +412,10 @@ class Volumio_ConfigFileParser(object):
             self.meter_config_volumio[REMOTE_DISCOVERY_PORT] = c.getint(CURRENT, REMOTE_DISCOVERY_PORT)
         except:
             self.meter_config_volumio[REMOTE_DISCOVERY_PORT] = 5579
+        try:
+            self.meter_config_volumio[REMOTE_SPECTRUM_PORT] = c.getint(CURRENT, REMOTE_SPECTRUM_PORT)
+        except:
+            self.meter_config_volumio[REMOTE_SPECTRUM_PORT] = 5581
         try:
             self.meter_config_volumio[QUEUE_MODE] = c.get(CURRENT, QUEUE_MODE)
         except:

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -908,6 +908,10 @@ class NetworkLevelServer:
         if not self.enabled or not self.sock:
             return
         
+        # Guard against None values (can occur during meter transitions or when data source has no data)
+        if left is None or right is None or mono is None:
+            return
+        
         try:
             # Pack as: sequence (uint32) + 3 floats (left, right, mono)
             data = struct.pack('<Ifff', self.seq, float(left), float(right), float(mono))

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -85,7 +85,8 @@ from volumio_configfileparser import (
     FONTSIZE_LIGHT, FONTSIZE_REGULAR, FONTSIZE_BOLD, FONTSIZE_DIGI, FONTCOLOR,
     FONT_STYLE_B, FONT_STYLE_R, FONT_STYLE_L,
     METER_BKP, RANDOM_TITLE, SPECTRUM, SPECTRUM_SIZE,
-    REMOTE_SERVER_ENABLED, REMOTE_SERVER_MODE, REMOTE_SERVER_PORT, REMOTE_DISCOVERY_PORT
+    REMOTE_SERVER_ENABLED, REMOTE_SERVER_MODE, REMOTE_SERVER_PORT, REMOTE_DISCOVERY_PORT,
+    REMOTE_SPECTRUM_PORT
 )
 
 # Indicator configuration constants - import with fallback for backward compatibility
@@ -940,6 +941,187 @@ class NetworkLevelServer:
 
 
 # =============================================================================
+# NetworkSpectrumServer - Broadcasts spectrum FFT data for remote displays
+# =============================================================================
+class NetworkSpectrumServer:
+    """
+    Broadcasts spectrum analyzer data over UDP for remote display clients.
+    
+    Supports two modes:
+    - Standalone (read_pipe=True): Reads FFT data directly from the spectrum pipe.
+      Use this in 'server' mode where there's no local display.
+    - Injected (read_pipe=False): Receives data via set_bins() from SpectrumOutput.
+      Use this in 'server_local' mode to avoid pipe contention with local Spectrum.
+    
+    Packet format (variable size, little-endian):
+        - seq (uint32): Sequence number for loss detection
+        - size (uint16): Number of frequency bins
+        - bins (float32 * size): Frequency bin values (0-100)
+    
+    Default spectrum_size is 20 bins (matching peppyalsa default).
+    """
+    
+    SPECTRUM_PIPE_PATH = '/tmp/myfifosa'
+    
+    def __init__(self, port=5581, enabled=True, spectrum_size=20, read_pipe=True):
+        """Initialize the spectrum server.
+        
+        :param port: UDP port to broadcast on (default 5581)
+        :param enabled: Whether broadcasting is enabled
+        :param spectrum_size: Number of frequency bins (default 20)
+        :param read_pipe: If True, read from pipe directly; if False, use set_bins()
+        """
+        self.port = port
+        self.enabled = enabled
+        self.spectrum_size = spectrum_size
+        self.read_pipe = read_pipe
+        self.seq = 0
+        self.sock = None
+        self.pipe = None
+        self._last_error_time = 0
+        self._first_broadcast_logged = False
+        self._pipe_size = 4 * spectrum_size  # 4 bytes per bin (int32)
+        self._injected_bins = None  # For injected mode
+        self._switched_to_pipe = False  # Track if we switched from injected to pipe mode
+        
+        if self.enabled:
+            try:
+                self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+                self.sock.setblocking(False)
+                mode_str = "pipe" if read_pipe else "injected"
+                log_debug(f"[NetworkSpectrumServer] Started on UDP port {port}, size={spectrum_size}, mode={mode_str}", "basic")
+            except Exception as e:
+                log_debug(f"[NetworkSpectrumServer] Failed to create socket: {e}", "basic")
+                self.sock = None
+                self.enabled = False
+            
+            # Only open pipe in standalone mode
+            if read_pipe:
+                self._open_pipe()
+    
+    def _open_pipe(self):
+        """Open the spectrum pipe for reading."""
+        try:
+            if os.path.exists(self.SPECTRUM_PIPE_PATH):
+                self.pipe = os.open(self.SPECTRUM_PIPE_PATH, os.O_RDONLY | os.O_NONBLOCK)
+                log_debug(f"[NetworkSpectrumServer] Opened pipe: {self.SPECTRUM_PIPE_PATH}", "basic")
+            else:
+                log_debug(f"[NetworkSpectrumServer] Pipe not found: {self.SPECTRUM_PIPE_PATH}", "basic")
+        except Exception as e:
+            log_debug(f"[NetworkSpectrumServer] Failed to open pipe: {e}", "basic")
+            self.pipe = None
+    
+    def _read_pipe_data(self):
+        """Read latest FFT data from the spectrum pipe.
+        
+        :return: List of frequency bin values, or None if no data
+        """
+        if self.pipe is None:
+            # Try to open pipe if it wasn't available at startup
+            if os.path.exists(self.SPECTRUM_PIPE_PATH):
+                self._open_pipe()
+            if self.pipe is None:
+                return None
+        
+        try:
+            # Read all available data, keep only the latest frame
+            data = None
+            while True:
+                try:
+                    tmp_data = os.read(self.pipe, self._pipe_size)
+                    if len(tmp_data) == self._pipe_size:
+                        data = tmp_data
+                    else:
+                        break
+                except BlockingIOError:
+                    break
+            
+            if data is None:
+                return None
+            
+            # Unpack as int32 values (same format peppyalsa writes)
+            # Each bin is a 4-byte little-endian integer
+            bins = []
+            for i in range(self.spectrum_size):
+                offset = i * 4
+                val = data[offset] + (data[offset + 1] << 8) + (data[offset + 2] << 16) + (data[offset + 3] << 24)
+                bins.append(float(val))
+            
+            return bins
+            
+        except Exception as e:
+            now = time.time()
+            if now - self._last_error_time > 10:
+                log_debug(f"[NetworkSpectrumServer] Pipe read error: {e}", "basic")
+                self._last_error_time = now
+            return None
+    
+    def set_bins(self, bins):
+        """Set spectrum bins for injected mode (called by SpectrumOutput).
+        
+        :param bins: List of frequency bin values
+        """
+        self._injected_bins = bins
+    
+    def broadcast(self):
+        """Broadcast spectrum data to all clients.
+        
+        In pipe mode, reads from pipe. In injected mode, uses set_bins() data.
+        """
+        if not self.enabled or not self.sock:
+            return
+        
+        # Get bins based on mode
+        if self.read_pipe:
+            bins = self._read_pipe_data()
+        else:
+            bins = self._injected_bins
+            self._injected_bins = None  # Clear after use
+        
+        if bins is None:
+            return
+        
+        try:
+            # Pack as: sequence (uint32) + size (uint16) + bins (float32 * size)
+            num_bins = len(bins)
+            fmt = '<IH' + str(num_bins) + 'f'
+            data = struct.pack(fmt, self.seq, num_bins, *bins)
+            self.sock.sendto(data, ('<broadcast>', self.port))
+            self.seq = (self.seq + 1) & 0xFFFFFFFF
+            
+            # Log first successful broadcast
+            if not self._first_broadcast_logged:
+                log_debug(f"[NetworkSpectrumServer] First broadcast: {num_bins} bins", "basic")
+                self._first_broadcast_logged = True
+                
+        except BlockingIOError:
+            pass
+        except Exception as e:
+            now = time.time()
+            if now - self._last_error_time > 10:
+                log_debug(f"[NetworkSpectrumServer] Broadcast error: {e}", "basic")
+                self._last_error_time = now
+    
+    def stop(self):
+        """Stop the server and close resources."""
+        self.enabled = False
+        if self.pipe is not None:
+            try:
+                os.close(self.pipe)
+            except Exception:
+                pass
+            self.pipe = None
+        if self.sock:
+            try:
+                self.sock.close()
+            except Exception:
+                pass
+            self.sock = None
+        log_debug("[NetworkSpectrumServer] Stopped", "basic")
+
+
+# =============================================================================
 # DiscoveryAnnouncer - Broadcasts server presence for client discovery
 # =============================================================================
 class DiscoveryAnnouncer:
@@ -951,6 +1133,7 @@ class DiscoveryAnnouncer:
             "service": "peppy_level_server",
             "version": 1,
             "level_port": 5580,
+            "spectrum_port": 5581,
             "volumio_port": 3000,
             "hostname": "volumio",
             "config_version": "a1b2c3d4"
@@ -962,12 +1145,13 @@ class DiscoveryAnnouncer:
     detect and re-fetch updated config.
     """
     
-    def __init__(self, discovery_port=5579, level_port=5580, volumio_port=3000, 
-                 interval=5.0, enabled=True, config_path=None):
+    def __init__(self, discovery_port=5579, level_port=5580, spectrum_port=5581,
+                 volumio_port=3000, interval=5.0, enabled=True, config_path=None):
         """Initialize the discovery announcer.
         
         :param discovery_port: UDP port for discovery broadcasts (default 5579)
         :param level_port: Level data port to advertise (default 5580)
+        :param spectrum_port: Spectrum data port to advertise (default 5581)
         :param volumio_port: Volumio socket.io port to advertise (default 3000)
         :param interval: Seconds between announcements (default 5.0)
         :param enabled: Whether announcements are enabled
@@ -975,6 +1159,7 @@ class DiscoveryAnnouncer:
         """
         self.discovery_port = discovery_port
         self.level_port = level_port
+        self.spectrum_port = spectrum_port
         self.volumio_port = volumio_port
         self.interval = interval
         self.enabled = enabled
@@ -1017,6 +1202,7 @@ class DiscoveryAnnouncer:
             "service": "peppy_level_server",
             "version": 1,
             "level_port": self.level_port,
+            "spectrum_port": self.spectrum_port,
             "volumio_port": self.volumio_port,
             "hostname": self.hostname,
             "config_version": self._config_version
@@ -3072,18 +3258,29 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
     level_server = None
     discovery_announcer = None
     
+    spectrum_server = None
+    
     if remote_enabled:
         level_port = meter_config_volumio.get(REMOTE_SERVER_PORT, 5580)
         discovery_port = meter_config_volumio.get(REMOTE_DISCOVERY_PORT, 5579)
+        spectrum_port = meter_config_volumio.get(REMOTE_SPECTRUM_PORT, 5581)
         
         # Start level server
         level_server = NetworkLevelServer(port=level_port, enabled=True)
+        
+        # Start spectrum server
+        # In server mode (headless): read from pipe directly (no local display to conflict)
+        # In server_local mode: use injected mode initially, will get data from SpectrumOutput
+        #                       if no local spectrum is active, will switch to pipe mode dynamically
+        read_pipe_mode = (remote_mode == "server")
+        spectrum_server = NetworkSpectrumServer(port=spectrum_port, enabled=True, read_pipe=read_pipe_mode)
         
         # Start discovery announcer (includes config version for change detection)
         config_path = os.path.join(PeppyPath, 'config.txt')
         discovery_announcer = DiscoveryAnnouncer(
             discovery_port=discovery_port,
             level_port=level_port,
+            spectrum_port=spectrum_port,
             volumio_port=3000,
             interval=5.0,
             enabled=True,
@@ -3282,8 +3479,12 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
         
         # Draw static assets and initial meter state
         draw_static_assets(mc)
-        pm.meter.run()
+        pm.meter.run()  # Just runs meter animation, does NOT trigger callbacks
         pg.display.update()
+        
+        # Note: SpectrumOutput is created by pm.meter.start() -> callback_start -> peppy_meter_start()
+        # which happens BEFORE overlay_init_for_meter() is called (see line 3577).
+        # We tap into callback.spectrum_output for network broadcast.
         
         # Store handler in overlay state
         overlay_state = {
@@ -3580,6 +3781,23 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
                             log_debug(f"[NetworkLevelServer] Broadcast exception: {e}", "basic")
                             level_server._logged_error = True
                 
+                # Broadcast spectrum data to remote clients (handler path)
+                if spectrum_server and spectrum_server.enabled:
+                    # In injected mode, get bins from SpectrumOutput (which reads the pipe)
+                    if not spectrum_server.read_pipe:
+                        if callback.spectrum_output:
+                            bins = callback.spectrum_output.get_current_bins()
+                            if bins:
+                                spectrum_server.set_bins(bins)
+                        else:
+                            # No local spectrum active - switch to pipe mode
+                            if not spectrum_server._switched_to_pipe:
+                                log_debug("[NetworkSpectrumServer] No local spectrum, switching to pipe mode", "basic")
+                                spectrum_server.read_pipe = True
+                                spectrum_server._open_pipe()
+                                spectrum_server._switched_to_pipe = True
+                    spectrum_server.broadcast()
+                
                 continue
         
         # Handle events
@@ -3617,6 +3835,23 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
                     log_debug(f"[NetworkLevelServer] Broadcast exception: {e}", "basic")
                     level_server._logged_error = True
         
+        # Broadcast spectrum data to remote clients (if server mode enabled)
+        if spectrum_server and spectrum_server.enabled:
+            # In injected mode, get bins from SpectrumOutput (which reads the pipe)
+            if not spectrum_server.read_pipe:
+                if callback.spectrum_output:
+                    bins = callback.spectrum_output.get_current_bins()
+                    if bins:
+                        spectrum_server.set_bins(bins)
+                else:
+                    # No local spectrum active - switch to pipe mode
+                    if not spectrum_server._switched_to_pipe:
+                        log_debug("[NetworkSpectrumServer] No local spectrum, switching to pipe mode", "basic")
+                        spectrum_server.read_pipe = True
+                        spectrum_server._open_pipe()
+                        spectrum_server._switched_to_pipe = True
+            spectrum_server.broadcast()
+        
         clock.tick(MAIN_LOOP_FRAME_RATE)
         
         # Frame timing trace
@@ -3632,6 +3867,8 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
                 log_debug("Exiting for config reload - stopping watchers only", "basic")
                 if level_server:
                     level_server.stop()
+                if spectrum_server:
+                    spectrum_server.stop()
                 if discovery_announcer:
                     discovery_announcer.stop()
                 final_handler = overlay_state.get("handler") if overlay_state else None
@@ -3669,6 +3906,9 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
     if level_server:
         log_debug("  Stopping level server", "verbose")
         level_server.stop()
+    if spectrum_server:
+        log_debug("  Stopping spectrum server", "verbose")
+        spectrum_server.stop()
     if discovery_announcer:
         log_debug("  Stopping discovery announcer", "verbose")
         discovery_announcer.stop()

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -2967,11 +2967,14 @@ class CallBack:
             if not meter_section_volumio[METER_VISIBLE]:
                 meter.stop()
             
-            # Start spectrum if visible
+            # Start spectrum if visible (but not if already set by remote client)
             if meter_section_volumio[SPECTRUM_VISIBLE]:
-                init_spectrum_debug(DEBUG_LEVEL_CURRENT, DEBUG_TRACE)
-                self.spectrum_output = SpectrumOutput(self.util, self.meter_config_volumio, CurDir)
-                self.spectrum_output.start()
+                # Check if spectrum_output was pre-injected (e.g., RemoteSpectrumOutput)
+                # If so, don't create a new SpectrumOutput - use the injected one
+                if self.spectrum_output is None:
+                    init_spectrum_debug(DEBUG_LEVEL_CURRENT, DEBUG_TRACE)
+                    self.spectrum_output = SpectrumOutput(self.util, self.meter_config_volumio, CurDir)
+                    self.spectrum_output.start()
         
         # Volume fade-in
         meter.set_volume(0.0)

--- a/volumio_peppymeter/volumio_spectrum.py
+++ b/volumio_peppymeter/volumio_spectrum.py
@@ -190,19 +190,13 @@ class SpectrumOutput(Thread):
         """
         if not hasattr(self, 'sp') or self.sp is None:
             _log_debug("[Spectrum] get_current_bins: sp is None", "verbose")
-            return getattr(self, '_last_good_bins', None)
+            return None
         
         # Get bar heights from Spectrum object
         if hasattr(self.sp, '_prev_bar_heights'):
             # Return a copy to avoid threading issues
+            # Always return current values - no caching, remote needs real-time data
             heights = list(self.sp._prev_bar_heights)
-            
-            # Cache last good values (non-zero) to reduce flicker
-            if any(h > 0 for h in heights):
-                self._last_good_bins = heights
-            elif hasattr(self, '_last_good_bins'):
-                # Return cached values if current frame is all zeros
-                return self._last_good_bins
             
             # Only log first successful retrieval
             if not hasattr(self, '_logged_first_bins'):
@@ -211,7 +205,7 @@ class SpectrumOutput(Thread):
             return heights
         
         _log_debug("[Spectrum] get_current_bins: _prev_bar_heights not found", "verbose")
-        return getattr(self, '_last_good_bins', None)
+        return None
 
     
     def stop_thread(self):


### PR DESCRIPTION
**Summary:**
- Add spectrum data broadcasting for remote displays via UDP
- Guard against None level values in broadcast
- Fix spectrum data stagnation in broadcasts by keeping last valid data
- Read spectrum heights from visual components for accurate real-time data

**Commits (4):**
- fix(remote): guard against None level values in broadcast
- feat(remote): add spectrum data broadcasting for remote displays
- fix(remote): improve spectrum broadcast for remote displays
- fix(remote): resolve spectrum data stagnation in broadcasts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main render loop and adds new UDP broadcast/discovery paths, which can impact runtime stability/performance and network behavior if edge cases or contention handling are wrong.
> 
> **Overview**
> Adds remote spectrum broadcasting over UDP for remote displays, including advertising a new `spectrum_port` via discovery and persisting a new `remoteSpectrumPort` setting (UI + default config + translations + config.txt sync).
> 
> Implements `NetworkSpectrumServer` in `volumio_peppymeter.py` with injected-vs-pipe modes to avoid local spectrum pipe contention, adds runtime fallbacks/switching when no local spectrum is active, and ensures clean shutdown/reload handling.
> 
> Hardens remote level streaming by skipping broadcasts when level values are `None`, and updates `SpectrumOutput` to avoid calling `pygame.display.update()` (reducing flicker) while exposing `get_current_bins()` so current visual spectrum data can be broadcast reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed94144ff1a73343eab58094033e064cea0a2ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->