### PR TITLE
feat(remote): Remote Display Server with config sync and spectrum streaming

### DIFF
--- a/UIConfig.json
+++ b/UIConfig.json
@@ -739,7 +739,8 @@
                                       "remoteServerMode",
                                       "remoteDiscoveryPort",
                                       "remoteServerPort",
-                                      "remoteSpectrumPort"
+                                      "remoteSpectrumPort",
+                                      "configSyncInterval"
                                       ]
                               },
                 "content": [
@@ -806,6 +807,21 @@
                                              {"max": 65535}
                                            ],
                              "value": 5581
+                            },
+                            {
+                             "id": "configSyncInterval",
+                             "element": "input",
+                             "type": "number",
+                             "visibleIf": {"field": "remoteServerEnabled", "value": true},
+                             "doc": "TRANSLATE.PEPPY_SCREENSAVER.CONFIG_SYNC_INTERVAL_DOC",
+                             "label": "TRANSLATE.PEPPY_SCREENSAVER.CONFIG_SYNC_INTERVAL",
+                             "attributes": [
+                                             {"placeholder": 1},
+                                             {"maxlength": 2},
+                                             {"min": 1},
+                                             {"max": 60}
+                                           ],
+                             "value": 1
                             }
                             ]
                 },

--- a/i18n/strings_de.json
+++ b/i18n/strings_de.json
@@ -221,6 +221,8 @@
     "REMOTE_SERVER_PORT":"Meter-Daten-Port",
     "REMOTE_SERVER_PORT_DOC":"UDP-Port zum Streamen von Audio-Pegeldaten an Remote-Anzeigen.<br /><br /><b>Standard: 5580</b><br /><br />Ändern, wenn dieser Port mit anderen Diensten kollidiert.",
     "REMOTE_SPECTRUM_PORT":"Spektrum-Daten-Port",
-    "REMOTE_SPECTRUM_PORT_DOC":"UDP-Port zum Streamen von Spektrumanalysator-Daten an Remote-Anzeigen.<br /><br /><b>Standard: 5581</b><br /><br />Ändern, wenn dieser Port mit anderen Diensten kollidiert."
+    "REMOTE_SPECTRUM_PORT_DOC":"UDP-Port zum Streamen von Spektrumanalysator-Daten an Remote-Anzeigen.<br /><br /><b>Standard: 5581</b><br /><br />Ändern, wenn dieser Port mit anderen Diensten kollidiert.",
+    "CONFIG_SYNC_INTERVAL":"Konfigurationssync-Intervall (Sekunden)",
+    "CONFIG_SYNC_INTERVAL_DOC":"Wie oft auf Konfigurationsänderungen geprüft und Remote-Clients benachrichtigt werden sollen.<br /><br /><b>Standard: 1 Sekunde</b><br /><br />Niedrigere Werte bedeuten, dass Remote-Clients Änderungen schneller erkennen. Bereich: 1-60 Sekunden."
   }
 }

--- a/i18n/strings_en.json
+++ b/i18n/strings_en.json
@@ -223,6 +223,8 @@
     "REMOTE_SERVER_PORT":"Meters data port",
     "REMOTE_SERVER_PORT_DOC":"UDP port for streaming audio level data to remote displays.<br /><br /><b>Default: 5580</b><br /><br />Change if this port conflicts with other services.",
     "REMOTE_SPECTRUM_PORT":"Spectrum data port",
-    "REMOTE_SPECTRUM_PORT_DOC":"UDP port for streaming spectrum analyzer data to remote displays.<br /><br /><b>Default: 5581</b><br /><br />Change if this port conflicts with other services."
+    "REMOTE_SPECTRUM_PORT_DOC":"UDP port for streaming spectrum analyzer data to remote displays.<br /><br /><b>Default: 5581</b><br /><br />Change if this port conflicts with other services.",
+    "CONFIG_SYNC_INTERVAL":"Config sync interval (seconds)",
+    "CONFIG_SYNC_INTERVAL_DOC":"How often to check for config changes and notify remote clients.<br /><br /><b>Default: 1 second</b><br /><br />Lower values mean remote clients detect changes faster. Range: 1-60 seconds."
   }
 }

--- a/i18n/strings_fr.json
+++ b/i18n/strings_fr.json
@@ -221,6 +221,8 @@
     "REMOTE_SERVER_PORT":"Port données des mètres",
     "REMOTE_SERVER_PORT_DOC":"Port UDP pour diffuser les données de niveau audio vers les affichages distants.<br /><br /><b>Par défaut: 5580</b><br /><br />Modifier si ce port entre en conflit avec d'autres services.",
     "REMOTE_SPECTRUM_PORT":"Port données du spectre",
-    "REMOTE_SPECTRUM_PORT_DOC":"Port UDP pour diffuser les données de l'analyseur de spectre vers les affichages distants.<br /><br /><b>Par défaut: 5581</b><br /><br />Modifier si ce port entre en conflit avec d'autres services."
+    "REMOTE_SPECTRUM_PORT_DOC":"Port UDP pour diffuser les données de l'analyseur de spectre vers les affichages distants.<br /><br /><b>Par défaut: 5581</b><br /><br />Modifier si ce port entre en conflit avec d'autres services.",
+    "CONFIG_SYNC_INTERVAL":"Intervalle de sync config (secondes)",
+    "CONFIG_SYNC_INTERVAL_DOC":"Fréquence de vérification des changements de configuration et notification des clients distants.<br /><br /><b>Par défaut: 1 seconde</b><br /><br />Des valeurs plus basses permettent aux clients distants de détecter les changements plus rapidement. Plage: 1-60 secondes."
   }
 }

--- a/index.js
+++ b/index.js
@@ -1830,10 +1830,16 @@ peppyScreensaver.prototype.getRemoteConfig = function () {
     var configContent = fs.readFileSync(PeppyConf, 'utf8');
     var configVersion = self.updateConfigVersion();
     
+    // Include persist settings for remote clients to manage their own persist file
+    var persistDuration = parseInt(self.config.get('persist_duration'), 10) || 0;
+    var persistDisplay = self.config.get('persist_display') || 'freeze';
+    
     defer.resolve({
       success: true,
       version: configVersion,
-      config: configContent
+      config: configContent,
+      persist_duration: persistDuration,
+      persist_display: persistDisplay
     });
   } catch (err) {
     self.logger.error(id + 'Failed to read config for remote client: ' + err.message);

--- a/index.js
+++ b/index.js
@@ -868,6 +868,13 @@ peppyScreensaver.prototype.getUIConfig = function() {
             }
             uiconf.sections[7].content[4].value = remoteSpectrumPort;
             
+            // config sync interval
+            var configSyncInterval = self.config.get('configSyncInterval');
+            if (configSyncInterval === undefined) {
+                configSyncInterval = peppy_config && peppy_config.current ? (parseInt(peppy_config.current['remote.config.sync.interval'], 10) || 1) : 1;
+            }
+            uiconf.sections[7].content[5].value = configSyncInterval;
+            
             // section 8 - Debug settings -----------------------------
             // debug level
             var debugLevel = peppy_config.current['debug.level'] || 'off';
@@ -1744,6 +1751,12 @@ peppyScreensaver.prototype.saveRemoteConf = function (confData) {
       noChanges = false;
   }
   
+  var configSyncInterval = self.minmax('config_sync_interval', confData.configSyncInterval, [1, 60, 1]);
+  if (self.config.get('configSyncInterval') !== configSyncInterval) {
+      self.config.set('configSyncInterval', configSyncInterval);
+      noChanges = false;
+  }
+  
   // Also update config.txt for Python/runtime
   if (fs.existsSync(PeppyConf)){
     var remoteServerEnabledStr = remoteServerEnabled ? 'true' : 'false';
@@ -1761,6 +1774,9 @@ peppyScreensaver.prototype.saveRemoteConf = function (confData) {
     }
     if (peppy_config.current['remote.spectrum.port'] != remoteSpectrumPort) {
         peppy_config.current['remote.spectrum.port'] = remoteSpectrumPort;
+    }
+    if (peppy_config.current['remote.config.sync.interval'] != configSyncInterval) {
+        peppy_config.current['remote.config.sync.interval'] = configSyncInterval;
     }
     
     if (!noChanges) {

--- a/volumio_peppymeter/volumio_configfileparser.py
+++ b/volumio_peppymeter/volumio_configfileparser.py
@@ -264,6 +264,7 @@ REMOTE_SERVER_MODE = "remote.server.mode"           # 'server', 'server_local'
 REMOTE_SERVER_PORT = "remote.server.port"           # UDP port for level data (default 5580)
 REMOTE_DISCOVERY_PORT = "remote.discovery.port"     # UDP port for discovery (default 5579)
 REMOTE_SPECTRUM_PORT = "remote.spectrum.port"       # UDP port for spectrum data (default 5581)
+REMOTE_CONFIG_SYNC_INTERVAL = "remote.config.sync.interval"  # Config check interval in seconds (default 1)
 
 class Volumio_ConfigFileParser(object):
     """ Configuration file parser """
@@ -419,6 +420,10 @@ class Volumio_ConfigFileParser(object):
             self.meter_config_volumio[REMOTE_SPECTRUM_PORT] = c.getint(CURRENT, REMOTE_SPECTRUM_PORT)
         except:
             self.meter_config_volumio[REMOTE_SPECTRUM_PORT] = 5581
+        try:
+            self.meter_config_volumio[REMOTE_CONFIG_SYNC_INTERVAL] = c.getint(CURRENT, REMOTE_CONFIG_SYNC_INTERVAL)
+        except:
+            self.meter_config_volumio[REMOTE_CONFIG_SYNC_INTERVAL] = 1
         try:
             self.meter_config_volumio[QUEUE_MODE] = c.get(CURRENT, QUEUE_MODE)
         except:

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -4103,6 +4103,11 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
             last_status = current_status
             idle_frame_skip = 0
         
+        # PERSIST MANAGER: Check for persist file management (remote client feature)
+        # If callback has a persist_manager, let it handle /tmp/peppy_persist based on status
+        if hasattr(callback, 'persist_manager') and callback.persist_manager:
+            callback.persist_manager.check_metadata_status(last_metadata)
+        
         if current_status in ("stop", "pause", ""):
             # When idle, skip every other frame to reduce CPU
             idle_frame_skip += 1

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -1450,7 +1450,8 @@ class DiscoveryAnnouncer:
     """
     
     def __init__(self, discovery_port=5579, level_port=5580, spectrum_port=5581,
-                 volumio_port=3000, interval=5.0, enabled=True, config_path=None):
+                 volumio_port=3000, interval=5.0, enabled=True, config_path=None,
+                 config_check_interval=1.0):
         """Initialize the discovery announcer.
         
         :param discovery_port: UDP port for discovery broadcasts (default 5579)
@@ -1460,6 +1461,7 @@ class DiscoveryAnnouncer:
         :param interval: Seconds between announcements (default 5.0)
         :param enabled: Whether announcements are enabled
         :param config_path: Path to config.txt for version hashing
+        :param config_check_interval: Seconds between config file checks (default 1.0)
         """
         self.discovery_port = discovery_port
         self.level_port = level_port
@@ -1473,7 +1475,7 @@ class DiscoveryAnnouncer:
         self.sock = None
         self._config_version = ""
         self._last_config_check = 0
-        self._config_check_interval = 5.0  # Check config every 5 seconds
+        self._config_check_interval = config_check_interval  # Configurable check interval (default 1s)
         self._broadcast_count = 0
         self._unknown_traffic = {}  # {ip: {"count": int, "last_seen": float}}
         self._local_ips = set()
@@ -1502,7 +1504,11 @@ class DiscoveryAnnouncer:
         self._update_config_version()
     
     def _update_config_version(self):
-        """Calculate MD5 hash of config file for version tracking."""
+        """Calculate MD5 hash of config file for version tracking.
+        
+        If a config change is detected, sends an immediate broadcast to notify
+        remote clients without waiting for the next scheduled interval.
+        """
         if not self.config_path:
             return
         
@@ -1516,8 +1522,11 @@ class DiscoveryAnnouncer:
                 self._config_version = new_hash
                 if old_version:
                     log_debug(f"[REMOTE:DISCOVERY] Config version changed: {old_version} -> {self._config_version}", "verbose")
+                    # Send immediate notification to clients (don't wait for next interval)
+                    self._send_immediate_broadcast()
                 else:
                     log_debug(f"[REMOTE:DISCOVERY] Config version: {self._config_version}", "verbose")
+            self._last_config_check = time.time()
         except Exception as e:
             log_debug(f"[REMOTE:DISCOVERY] Config hash error: {e}", "verbose")
     
@@ -3711,6 +3720,8 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
         level_port = meter_config_volumio.get(REMOTE_SERVER_PORT, 5580)
         discovery_port = meter_config_volumio.get(REMOTE_DISCOVERY_PORT, 5579)
         spectrum_port = meter_config_volumio.get(REMOTE_SPECTRUM_PORT, 5581)
+        # Use string literal for backward compatibility with clients that may not have the constant
+        config_sync_interval = meter_config_volumio.get("remote.config.sync.interval", 1)
         
         # Start level server
         level_server = NetworkLevelServer(port=level_port, enabled=True)
@@ -3732,7 +3743,8 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
             volumio_port=3000,
             interval=5.0,
             enabled=True,
-            config_path=config_path
+            config_path=config_path,
+            config_check_interval=float(config_sync_interval)
         )
         discovery_announcer.start()
         


### PR DESCRIPTION
## Summary

- Add Remote Display Server feature for streaming visualization data to remote clients
- Add spectrum data broadcasting alongside meter level data
- Add configurable config sync interval (default 1s) with immediate broadcast on changes
- Add persist countdown support for remote clients
- Add trace logging and client registration for diagnostics
- Fix spectrum flicker in server_local mode
- Refactor UI to improve Remote Display settings organization

## Changes

### Remote Display Server
- Stream meter levels and spectrum FFT data via UDP
- Auto-discovery broadcasts for client connection
- Config version tracking with immediate broadcast on changes
- Client registration with heartbeat monitoring
- Trace logging for debugging network issues

### UI Improvements
- Move Remote Display section before Debug/Profiling
- Reorder and rename port labels for clarity
- Add Config Sync Interval setting (1-60 seconds)

### Bug Fixes
- Prevent spectrum flicker in server_local mode (pipe contention)
- Guard against None values in level broadcasts
- Persist UI settings across restarts