### PR TITLE
fix: 48 kHz DAC lock with Peppy + FusionDSP bridge (postDsp → postpeppyalsa)

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,24 +187,6 @@ peppyScreensaver.prototype.onStart = function() {
       }
       self.switch_alsaConfig(alsaconf);
       
-      // When FusionDSP integration is on: after system ready, restore stream params once (covers FusionDSP enabled after Peppy start; independent of plugin priority)
-      if (self.config.get('useDSP')) {
-        var readyAttempts = 0;
-        var readyInterval = setInterval(function () {
-          readyAttempts++;
-          if (process.env.VOLUMIO_SYSTEM_STATUS === 'ready') {
-            clearInterval(readyInterval);
-            if (fs.existsSync(dsp_config) && self.config.get('useDSP')) {
-              self.restoreFusionStreamParamsForIntegration();
-            }
-            return;
-          }
-          if (readyAttempts >= 40) {
-            clearInterval(readyInterval);
-          }
-        }, 1500);
-      }
-      
       // event callback if outputdevice or mixer changed
       self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.switch_alsaModular.bind(self));
       
@@ -1006,10 +988,8 @@ peppyScreensaver.prototype.savePeppyMeterConf = function (confData) {
     //var config = ini.parse(fs.readFileSync(PeppyConf, 'utf-8'));
 
     // write DSP
-    var didEnableDSP = false;
     if (self.config.get('useDSP') != confData.useDSP) {
         self.config.set('useDSP', confData.useDSP);
-        if (confData.useDSP) didEnableDSP = true;
         self.checkDSPactive(!confData.useDSP);
         self.switch_Spotify(!confData.useDSP);
         noChanges = false;

--- a/index.js
+++ b/index.js
@@ -187,6 +187,24 @@ peppyScreensaver.prototype.onStart = function() {
       }
       self.switch_alsaConfig(alsaconf);
       
+      // When FusionDSP integration is on: after system ready, restore stream params once (covers FusionDSP enabled after Peppy start; independent of plugin priority)
+      if (self.config.get('useDSP')) {
+        var readyAttempts = 0;
+        var readyInterval = setInterval(function () {
+          readyAttempts++;
+          if (process.env.VOLUMIO_SYSTEM_STATUS === 'ready') {
+            clearInterval(readyInterval);
+            if (fs.existsSync(dsp_config) && self.config.get('useDSP')) {
+              self.restoreFusionStreamParamsForIntegration();
+            }
+            return;
+          }
+          if (readyAttempts >= 40) {
+            clearInterval(readyInterval);
+          }
+        }, 1500);
+      }
+      
       // event callback if outputdevice or mixer changed
       self.commandRouter.sharedVars.registerCallback('alsa.outputdevice', self.switch_alsaModular.bind(self));
       

--- a/index.js
+++ b/index.js
@@ -1007,10 +1007,6 @@ peppyScreensaver.prototype.savePeppyMeterConf = function (confData) {
         uiNeedsReboot = true;
     }
 
-    if (didEnableDSP && fs.existsSync(dsp_config)) {
-      self.restoreFusionStreamParamsForIntegration();
-    }
-
     // write spotify /USB-DAC
     if (self.getPluginStatus ('music_service', 'spop') === 'STARTED') {
         if (confData.useDSP) {
@@ -2150,6 +2146,12 @@ peppyScreensaver.prototype.switch_alsaConfig = function (alsaConf) {
                     }
                 });
             }, 1000); // Wait for MPD to fully restart
+            // When modular ALSA + FusionDSP integration: restore Fusion stream params *after* ALSA/MPD update so Fusion reconfigures CamillaDSP against the new chain (avoids PB "giving up" and 48k lock)
+            if (alsaConf === 0 && fs.existsSync(dsp_config) && self.config.get('useDSP')) {
+                setTimeout(function() {
+                    self.restoreFusionStreamParamsForIntegration();
+                }, 500);
+            }
         });
     defer.resolve();
     return defer.promise;    


### PR DESCRIPTION
### Problem
With **Fusion DSP integration (bridge)** enabled, the DAC stayed at **48 kHz** instead of following the source (e.g. 384k). CamillaDSP logged `PB: giving up after 100 write attempts` / `Playback error: Aborting playback after too many write attempts`.

**Cause:** When the bridge is on, `postDsp` pointed to **Peppyalsa** (a multi PCM that opens both the DAC path and the 48k Dummy meter path in one open). ALSA negotiated a single format for that open → 48k. CamillaDSP then failed writing to the device and gave up.

### Solution
When Fusion integration is **on**, the Peppy plugin now contributes its ALSA snippet under the filename **postpeppyalsa.postPeppyalsa.5.conf** instead of **Peppyalsa.postPeppyalsa.5.conf**. The backend builds the chain from contribution filenames (`inPCM.outPCM.conf`), so the merged config gets **postDsp → postpeppyalsa** (DAC-only) instead of **postDsp → Peppyalsa** (multi with Dummy). CamillaDSP then opens only the DAC at the correct rate; the 48k lock and write failures go away.

**Trade-off:** With `postDsp` → postpeppyalsa, the Peppy VU meter no longer receives a duplicate from this path; meter behaviour can be revisited later if needed.
