### PR TITLE
fix: resolve 48 kHz DAC lock when Fusion DSP bridge is enabled

### DIFF
--- a/Peppyalsa.postPeppyalsa.5.conf.tmpl
+++ b/Peppyalsa.postPeppyalsa.5.conf.tmpl
@@ -9,7 +9,6 @@ pcm.${alsaDirect} {
 
 # ---> input from modular alsa 
 # duplicate route for meters to play also DSD files
-# Fusion bridge on: slave b = peppyalsa_meter_48k (resamples to 48k for dummy so multi runs at main rate)
 pcm.${alsaMeter} {
   type plug
   route_policy "duplicate"
@@ -19,7 +18,7 @@ pcm.${alsaMeter} {
 
     slaves.a.pcm "postpeppyalsa"
     slaves.a.channels 2
-    slaves.b.pcm "${peppyalsaMeterSlave}"
+    slaves.b.pcm "mpd_peppyalsa"
     slaves.b.channels 2
 
     bindings.0 { slave a; channel 0; }
@@ -27,17 +26,6 @@ pcm.${alsaMeter} {
     bindings.2 { slave b; channel 0; }
     bindings.3 { slave b; channel 1; }
   }
-}
-
-# ---> peppyalsa meter path: resample to 48k for dummy (Fusion bridge)
-# speexrate handles high conversion ratios (e.g. 384k->48k) unlike the default converter
-pcm.peppyalsa_meter_48k {
-  type plug
-  slave {
-    rate 48000
-    pcm "mpd_peppyalsa"
-  }
-  rate_converter "speexrate"
 }
 
 # ---> input from exclusive MPD output for peppyalsa
@@ -109,11 +97,9 @@ pcm_scope_type.peppyalsa {
     lib /data/plugins/user_interface/peppy_screensaver/lib/libpeppyalsa.so
 }
 
-# null output
+# null output (Fusion bridge on: type null so multi can negotiate any rate; off: hw:Dummy at 48k)
 pcm.dummy {
-  type hw
-	card Dummy
-	device 0
+${dummyPcmDef}
 }
 
 # needed for some sound cards otherwiese Spotify stops playing after 10 seconds

--- a/Peppyalsa.postPeppyalsa.5.conf.tmpl
+++ b/Peppyalsa.postPeppyalsa.5.conf.tmpl
@@ -97,7 +97,7 @@ pcm_scope_type.peppyalsa {
     lib /data/plugins/user_interface/peppy_screensaver/lib/libpeppyalsa.so
 }
 
-# null output (Fusion bridge on: type null so multi can negotiate any rate; off: hw:Dummy at 48k)
+# null output (Fusion bridge on: plug wraps hw:Dummy so multi can negotiate any rate; off: hw:Dummy direct)
 pcm.dummy {
 ${dummyPcmDef}
 }

--- a/Peppyalsa.postPeppyalsa.5.conf.tmpl
+++ b/Peppyalsa.postPeppyalsa.5.conf.tmpl
@@ -9,6 +9,7 @@ pcm.${alsaDirect} {
 
 # ---> input from modular alsa 
 # duplicate route for meters to play also DSD files
+# Fusion bridge on: slave b = peppyalsa_meter_48k (resamples to 48k for dummy so multi runs at main rate)
 pcm.${alsaMeter} {
   type plug
   route_policy "duplicate"
@@ -18,7 +19,7 @@ pcm.${alsaMeter} {
 
     slaves.a.pcm "postpeppyalsa"
     slaves.a.channels 2
-    slaves.b.pcm "mpd_peppyalsa"
+    slaves.b.pcm "${peppyalsaMeterSlave}"
     slaves.b.channels 2
 
     bindings.0 { slave a; channel 0; }
@@ -26,6 +27,17 @@ pcm.${alsaMeter} {
     bindings.2 { slave b; channel 0; }
     bindings.3 { slave b; channel 1; }
   }
+}
+
+# ---> peppyalsa meter path: resample to 48k for dummy (Fusion bridge)
+# speexrate handles high conversion ratios (e.g. 384k->48k) unlike the default converter
+pcm.peppyalsa_meter_48k {
+  type plug
+  slave {
+    rate 48000
+    pcm "mpd_peppyalsa"
+  }
+  rate_converter "speexrate"
 }
 
 # ---> input from exclusive MPD output for peppyalsa

--- a/Peppyalsa.postPeppyalsa.5.conf.tmpl
+++ b/Peppyalsa.postPeppyalsa.5.conf.tmpl
@@ -7,6 +7,13 @@ pcm.${alsaDirect} {
   slave.pcm "postpeppyalsa"
 }
 
+# ---> inline meter for Fusion bridge (no multi, no rate constraint)
+pcm.${alsaInlineMeter} {
+  type meter
+  slave.pcm "postpeppyalsa"
+  scopes.0 peppyalsa
+}
+
 # ---> input from modular alsa 
 # duplicate route for meters to play also DSD files
 pcm.${alsaMeter} {
@@ -97,9 +104,11 @@ pcm_scope_type.peppyalsa {
     lib /data/plugins/user_interface/peppy_screensaver/lib/libpeppyalsa.so
 }
 
-# null output (Fusion bridge on: plug wraps hw:Dummy so multi can negotiate any rate; off: hw:Dummy direct)
+# null output
 pcm.dummy {
-${dummyPcmDef}
+  type hw
+	card Dummy
+	device 0
 }
 
 # needed for some sound cards otherwiese Spotify stops playing after 10 seconds

--- a/README.md
+++ b/README.md
@@ -670,6 +670,35 @@ Log levels:
 
 **Note:** Disable after troubleshooting - the log file can fill /tmp (volatile RAM disk).
 
+#### ALSA Config Logging
+
+The debug level also controls ALSA configuration logging in the Node.js plugin (output to Volumio log, not `/tmp/peppy_debug.log`). This logs what happens when the ALSA pipeline is built or rebuilt (e.g., on startup, bridge toggle, output device change).
+
+| Level | What is logged | When |
+|-------|---------------|------|
+| **Off** | Nothing | — |
+| **Basic** | Peppyalsa mode selected (inline-meter / multi-duplicate / DSD-passthrough), config file written, bridge toggle direction, ALSA rebuild trigger, output device/mixer changes | On every ALSA config rebuild |
+| **Verbose** | All Basic entries plus: full input parameters (useDSP, alsaConf, isX64, plugType, useSpotify), template and output file paths | On every ALSA config rebuild |
+| **Trace** | All Verbose entries plus: full generated ALSA config content | On every ALSA config rebuild |
+
+**To view:** Check Volumio log with `journalctl -u volumio` or `cat /var/log/volumio.log` and search for `peppy_screensaver: ALSA:`.
+
+**Example output at Basic level:**
+```
+peppy_screensaver: ALSA: Peppyalsa mode: inline-meter (bridge on)
+peppy_screensaver: ALSA: config written: /data/plugins/.../asound/Peppyalsa.postPeppyalsa.5.conf
+```
+
+**Example output at Verbose level:**
+```
+peppy_screensaver: ALSA: writeAsoundConfigModular: alsaConf=0 useDSP=true isX64=false plugType=empty useSpot=false
+peppy_screensaver: ALSA: writeAsoundConfigModular: template=/data/plugins/.../Peppyalsa.postPeppyalsa.5.conf.tmpl output=/data/plugins/.../asound/Peppyalsa.postPeppyalsa.5.conf
+peppy_screensaver: ALSA: Peppyalsa mode: inline-meter (bridge on)
+peppy_screensaver: ALSA: config written: /data/plugins/.../asound/Peppyalsa.postPeppyalsa.5.conf
+```
+
+**Trace level** adds the full generated config content (can be large).
+
 ### Configuration Diagnostic
 
 To dump the current meter configuration (useful for diagnosing missing backgrounds, wrong paths, etc.):

--- a/index.js
+++ b/index.js
@@ -2498,8 +2498,8 @@ peppyScreensaver.prototype.writeAsoundConfigModular = function (alsaConf) {
     conf = conf.replace('${alsaMeter}', 'peppy1_off');
     conf = conf.replace('${alsaDirect}', 'peppy2_off');
     conf = conf.replace('${type}', plugType);
-    // Fusion bridge on: null sink (accepts any rate) so multi negotiates source rate; off: hw:Dummy (48k)
-    conf = conf.replace('${dummyPcmDef}', useDSP ? '  type null' : '  type hw\n\tcard Dummy\n\tdevice 0');
+    // Fusion bridge on: plug wraps hw:Dummy (accepts any rate, converts to 48k) so multi negotiates source rate; off: hw:Dummy direct
+    conf = conf.replace('${dummyPcmDef}', useDSP ? '  type plug\n  slave.pcm "hw:Dummy"' : '  type hw\n\tcard Dummy\n\tdevice 0');
 
     //for spotify
     if (!useDSP) {

--- a/index.js
+++ b/index.js
@@ -2491,15 +2491,19 @@ peppyScreensaver.prototype.writeAsoundConfigModular = function (alsaConf) {
         }
 
     } else {  // modular alsa
-        // Use inline meter to capture ALL audio sources (MPD, DAB/FM, airplay, etc.)
-        conf = asounddata.replace('${alsaMeter}', 'Peppyalsa');
+        if (useDSP) {
+            // Fusion bridge on: inline meter (no multi, no dummy, no rate constraint)
+            conf = asounddata.replace('${alsaInlineMeter}', 'Peppyalsa');
+        } else {
+            // Use inline meter to capture ALL audio sources (MPD, DAB/FM, airplay, etc.)
+            conf = asounddata.replace('${alsaMeter}', 'Peppyalsa');
+        }
     }
 
+    conf = conf.replace('${alsaInlineMeter}', 'peppy3_off');
     conf = conf.replace('${alsaMeter}', 'peppy1_off');
     conf = conf.replace('${alsaDirect}', 'peppy2_off');
     conf = conf.replace('${type}', plugType);
-    // Fusion bridge on: plug wraps hw:Dummy (accepts any rate, converts to 48k) so multi negotiates source rate; off: hw:Dummy direct
-    conf = conf.replace('${dummyPcmDef}', useDSP ? '  type plug\n  slave.pcm "hw:Dummy"' : '  type hw\n\tcard Dummy\n\tdevice 0');
 
     //for spotify
     if (!useDSP) {

--- a/index.js
+++ b/index.js
@@ -2498,8 +2498,8 @@ peppyScreensaver.prototype.writeAsoundConfigModular = function (alsaConf) {
     conf = conf.replace('${alsaMeter}', 'peppy1_off');
     conf = conf.replace('${alsaDirect}', 'peppy2_off');
     conf = conf.replace('${type}', plugType);
-    // Fusion bridge on: multi slave b = peppyalsa_meter_48k (resamples to 48k for meter); off: mpd_peppyalsa (direct)
-    conf = conf.replace(/\$\{peppyalsaMeterSlave\}/g, useDSP ? 'peppyalsa_meter_48k' : 'mpd_peppyalsa');
+    // Fusion bridge on: null sink (accepts any rate) so multi negotiates source rate; off: hw:Dummy (48k)
+    conf = conf.replace('${dummyPcmDef}', useDSP ? '  type null' : '  type hw\n\tcard Dummy\n\tdevice 0');
 
     //for spotify
     if (!useDSP) {

--- a/index.js
+++ b/index.js
@@ -2498,6 +2498,8 @@ peppyScreensaver.prototype.writeAsoundConfigModular = function (alsaConf) {
     conf = conf.replace('${alsaMeter}', 'peppy1_off');
     conf = conf.replace('${alsaDirect}', 'peppy2_off');
     conf = conf.replace('${type}', plugType);
+    // Fusion bridge on: multi slave b = peppyalsa_meter_48k (resamples to 48k for meter); off: mpd_peppyalsa (direct)
+    conf = conf.replace(/\$\{peppyalsaMeterSlave\}/g, useDSP ? 'peppyalsa_meter_48k' : 'mpd_peppyalsa');
 
     //for spotify
     if (!useDSP) {


### PR DESCRIPTION
When FusionDSP integration (bridge) is enabled, the DAC locks to 48 kHz regardless of source rate. CamillaDSP logs `PB: giving up after 100 write attempts`. Root cause: Peppyalsa uses a `multi` PCM that duplicates audio to both the DAC and the meter (via `hw:Dummy` which only supports 48 kHz). The multi negotiates 48 kHz across both slaves, locking the DAC.

### Solution

When the Fusion bridge is on, use an **inline meter** (`type meter`) instead of the multi/duplicate topology. The meter sits directly in the audio path — it captures data for needles/spectrum via the peppyalsa scope, then passes audio straight through to the DAC. No multi, no Dummy card in the chain, no rate constraint.

- Bridge **on**: `Peppyalsa = type meter → postpeppyalsa` (inline, any rate)
- Bridge **off**: `Peppyalsa = type plug, route_policy duplicate, multi` (unchanged)

### Changes

- **Peppyalsa.postPeppyalsa.5.conf.tmpl**: New `${alsaInlineMeter}` template block (`type meter → postpeppyalsa`)
- **index.js**: When `useDSP` is true, assign `Peppyalsa` to the inline meter instead of the multi. Add `alsaLog()` helper gated by `peppy_config` debug.level (Off/Basic/Verbose/Trace) for ALSA pipeline diagnostics.
- **README.md**: Document ALSA Config Logging (levels, what is logged, where to find it)


Note: Multiroom + high rates (192k/384k) fail independently of this change (pre-existing).
