### PR TITLE
feat: Time display - optional style in pos (x,y,style) like playinfo

### DIFF
--- a/volumio_peppymeter/volumio_basic.py
+++ b/volumio_peppymeter/volumio_basic.py
@@ -60,7 +60,9 @@ from volumio_configfileparser import (
     PLAY_TYPE_POS, PLAY_TYPE_COLOR, PLAY_TYPE_DIM,
     PLAY_SAMPLE_POS, PLAY_SAMPLE_STYLE, PLAY_SAMPLE_MAX,
     TIME_REMAINING_POS, TIMECOLOR,
-    TIME_ELAPSED_POS, TIME_ELAPSED_COLOR, TIME_TOTAL_POS, TIME_TOTAL_COLOR,
+    TIME_REMAINING_STYLE, TIME_REMAINING_FONT, TIME_REMAINING_FONTSIZE,
+    TIME_ELAPSED_POS, TIME_ELAPSED_COLOR, TIME_ELAPSED_STYLE, TIME_ELAPSED_FONT, TIME_ELAPSED_FONTSIZE,
+    TIME_TOTAL_POS, TIME_TOTAL_COLOR, TIME_TOTAL_STYLE, TIME_TOTAL_FONT, TIME_TOTAL_FONTSIZE,
     FONTSIZE_LIGHT, FONTSIZE_REGULAR, FONTSIZE_BOLD, FONTSIZE_DIGI, FONTCOLOR,
     FONT_STYLE_B, FONT_STYLE_R, FONT_STYLE_L
 )
@@ -947,21 +949,21 @@ class BasicHandler:
         self.bgr_surface = self.screen.copy()
         log_debug("  Background surface captured for layer composition", "verbose")
         
-        # Store rects for layer composition clearing
-        if self.time_pos:
-            time_w = self.fontDigi.size('00:00')[0] + 10
-            time_h = self.fontDigi.get_linesize()
+        # Store rects for layer composition clearing (use effective time font per field for size)
+        if self.time_pos and self.font_time_remaining:
+            time_w = self.font_time_remaining.size('00:00')[0] + 10
+            time_h = self.font_time_remaining.get_linesize()
             self.time_rect = pg.Rect(self.time_pos[0], self.time_pos[1], time_w, time_h)
             log_debug(f"  time_rect: x={self.time_rect.x}, y={self.time_rect.y}, w={self.time_rect.width}, h={self.time_rect.height}", "verbose")
-        if self.time_elapsed_pos and self.fontDigi:
-            time_w = self.fontDigi.size('00:00')[0] + 10
-            time_h = self.fontDigi.get_linesize()
+        if self.time_elapsed_pos and self.font_time_elapsed:
+            time_w = self.font_time_elapsed.size('00:00')[0] + 10
+            time_h = self.font_time_elapsed.get_linesize()
             self.time_elapsed_rect = pg.Rect(self.time_elapsed_pos[0], self.time_elapsed_pos[1], time_w, time_h)
         else:
             self.time_elapsed_rect = None
-        if self.time_total_pos and self.fontDigi:
-            time_w = self.fontDigi.size('00:00')[0] + 10
-            time_h = self.fontDigi.get_linesize()
+        if self.time_total_pos and self.font_time_total:
+            time_w = self.font_time_total.size('00:00')[0] + 10
+            time_h = self.font_time_total.get_linesize()
             self.time_total_rect = pg.Rect(self.time_total_pos[0], self.time_total_pos[1], time_w, time_h)
         else:
             self.time_total_rect = None
@@ -1154,13 +1156,70 @@ class BasicHandler:
         else:
             self.fontB = pg.font.SysFont("DejaVuSans", size_bold, bold=True)
         
-        # Digital font for time
-        digi_path = os.path.join(os.path.dirname(__file__), 'fonts', 'DSEG7Classic-Italic.ttf')
-        if os.path.exists(digi_path):
-            self.fontDigi = pg.font.Font(digi_path, size_digi)
-            log_debug(f"  Font digi: loaded {digi_path}", "verbose")
+        # Digital font for time (default; used when per-field font/size not set)
+        default_digi_path = os.path.join(os.path.dirname(__file__), 'fonts', 'DSEG7Classic-Italic.ttf')
+        if os.path.exists(default_digi_path):
+            self.fontDigi = pg.font.Font(default_digi_path, size_digi)
+            log_debug(f"  Font digi: loaded {default_digi_path}", "verbose")
         else:
             self.fontDigi = pg.font.SysFont("DejaVuSans", size_digi)
+
+        # Per-field time fonts (remaining, elapsed, total): optional font path + fontsize; fallback to fontDigi
+        meter_path = os.path.join(self.config.get(BASE_PATH), self.config.get(SCREEN_INFO)[METER_FOLDER])
+        self._time_font_cache = {}  # (path, size) -> font, to reuse when same path+size
+
+        def resolve_time_font_path(font_value):
+            if not font_value:
+                return default_digi_path
+            if os.path.isabs(font_value) and os.path.exists(font_value):
+                return font_value
+            for base in (meter_path, font_path):
+                if base:
+                    p = os.path.join(base.rstrip(os.sep), font_value.lstrip(os.sep))
+                    if os.path.exists(p):
+                        return p
+            return default_digi_path
+
+        def get_time_font(path, size):
+            if (path, size) == (default_digi_path, size_digi):
+                return self.fontDigi
+            key = (path, size)
+            if key not in self._time_font_cache:
+                if os.path.exists(path):
+                    self._time_font_cache[key] = pg.font.Font(path, size)
+                    log_debug(f"  Time font: loaded {path} size={size}", "verbose")
+                else:
+                    self._time_font_cache[key] = pg.font.SysFont("DejaVuSans", size)
+            return self._time_font_cache[key]
+
+        path_remaining = resolve_time_font_path(mc_vol.get(TIME_REMAINING_FONT))
+        size_remaining = mc_vol.get(TIME_REMAINING_FONTSIZE) or size_digi
+        path_elapsed = resolve_time_font_path(mc_vol.get(TIME_ELAPSED_FONT))
+        size_elapsed = mc_vol.get(TIME_ELAPSED_FONTSIZE) or size_digi
+        path_total = resolve_time_font_path(mc_vol.get(TIME_TOTAL_FONT))
+        size_total = mc_vol.get(TIME_TOTAL_FONTSIZE) or size_digi
+
+        self.fontDigiRemaining = get_time_font(path_remaining, size_remaining)
+        self.fontDigiElapsed = get_time_font(path_elapsed, size_elapsed)
+        self.fontDigiTotal = get_time_font(path_total, size_total)
+
+        # Effective font per time field: style from pos (x,y,style) — light/regular/bold use text font, digi or omit = digi font
+        def norm_time_style(s):
+            if not s:
+                return FONT_STYLE_R
+            s = s.strip().lower()
+            if s == "light":
+                return FONT_STYLE_L
+            if s == "bold":
+                return FONT_STYLE_B
+            return FONT_STYLE_R
+
+        style_rem = mc_vol.get(TIME_REMAINING_STYLE)
+        style_elapsed = mc_vol.get(TIME_ELAPSED_STYLE)
+        style_total = mc_vol.get(TIME_TOTAL_STYLE)
+        self.font_time_remaining = self.fontDigiRemaining if (not style_rem or style_rem == "digi") else self._font_for_style(norm_time_style(style_rem))
+        self.font_time_elapsed = self.fontDigiElapsed if (not style_elapsed or style_elapsed == "digi") else self._font_for_style(norm_time_style(style_elapsed))
+        self.font_time_total = self.fontDigiTotal if (not style_total or style_total == "digi") else self._font_for_style(norm_time_style(style_total))
     
     def _font_for_style(self, style):
         """Get font for style."""
@@ -1423,14 +1482,14 @@ class BasicHandler:
                     else:
                         t_color = self.time_color
                     
-                    self.last_time_surf = self.fontDigi.render(time_str, True, t_color)
+                    self.last_time_surf = self.font_time_remaining.render(time_str, True, t_color)
                     self.screen.blit(self.last_time_surf, self.time_pos)
                     
                     if DEBUG_LEVEL_CURRENT == "trace" and DEBUG_TRACE.get("time", False):
                         log_debug(f"[Time] OUTPUT: rendered '{time_str}' at {self.time_pos}, color={t_color}", "trace", "time")
 
         # LAYER: Elapsed time (when time.elapsed.pos set)
-        if self.time_elapsed_pos and self.fontDigi:
+        if self.time_elapsed_pos and self.font_time_elapsed:
             seek_ms = meta.get("seek") or 0
             elapsed_sec = max(0, int(seek_ms) // 1000)
             elapsed_str = f"{elapsed_sec // 60:02d}:{elapsed_sec % 60:02d}"
@@ -1439,11 +1498,11 @@ class BasicHandler:
                 if self.bgr_surface and self.time_elapsed_rect:
                     self.screen.blit(self.bgr_surface, self.time_elapsed_rect.topleft, self.time_elapsed_rect)
                     dirty_rects.append(self.time_elapsed_rect.copy())
-                surf = self.fontDigi.render(elapsed_str, True, self.time_elapsed_color)
+                surf = self.font_time_elapsed.render(elapsed_str, True, self.time_elapsed_color)
                 self.screen.blit(surf, self.time_elapsed_pos)
 
         # LAYER: Total time (when time.total.pos set)
-        if self.time_total_pos and self.fontDigi:
+        if self.time_total_pos and self.font_time_total:
             duration_sec = max(0, int(meta.get("duration") or 0))
             total_str = f"{duration_sec // 60:02d}:{duration_sec % 60:02d}"
             if total_str != self.last_total_str:
@@ -1451,7 +1510,7 @@ class BasicHandler:
                 if self.bgr_surface and self.time_total_rect:
                     self.screen.blit(self.bgr_surface, self.time_total_rect.topleft, self.time_total_rect)
                     dirty_rects.append(self.time_total_rect.copy())
-                surf = self.fontDigi.render(total_str, True, self.time_total_color)
+                surf = self.font_time_total.render(total_str, True, self.time_total_color)
                 self.screen.blit(surf, self.time_total_pos)
 
         # LAYER: Sample rate / format icon

--- a/volumio_peppymeter/volumio_cassette.py
+++ b/volumio_peppymeter/volumio_cassette.py
@@ -64,7 +64,9 @@ from volumio_configfileparser import (
     PLAY_TYPE_POS, PLAY_TYPE_COLOR, PLAY_TYPE_DIM,
     PLAY_SAMPLE_POS, PLAY_SAMPLE_STYLE, PLAY_SAMPLE_MAX,
     TIME_REMAINING_POS, TIMECOLOR,
-    TIME_ELAPSED_POS, TIME_ELAPSED_COLOR, TIME_TOTAL_POS, TIME_TOTAL_COLOR,
+    TIME_REMAINING_STYLE, TIME_REMAINING_FONT, TIME_REMAINING_FONTSIZE,
+    TIME_ELAPSED_POS, TIME_ELAPSED_COLOR, TIME_ELAPSED_STYLE, TIME_ELAPSED_FONT, TIME_ELAPSED_FONTSIZE,
+    TIME_TOTAL_POS, TIME_TOTAL_COLOR, TIME_TOTAL_STYLE, TIME_TOTAL_FONT, TIME_TOTAL_FONTSIZE,
     FONTSIZE_LIGHT, FONTSIZE_REGULAR, FONTSIZE_BOLD, FONTSIZE_DIGI, FONTCOLOR,
     FONT_STYLE_B, FONT_STYLE_R, FONT_STYLE_L
 )
@@ -1462,22 +1464,22 @@ class CassetteHandler:
         # Type rect
         self.type_rect = pg.Rect(self.type_pos[0], self.type_pos[1], type_dim[0], type_dim[1]) if (self.type_pos and type_dim) else None
         
-        # Time rect (for clearing from bgr_surface)
-        if self.time_pos and self.fontDigi:
-            time_width = self.fontDigi.size('00:00')[0] + 10
-            time_height = self.fontDigi.get_linesize()
+        # Time rect (for clearing from bgr_surface; use effective time font per field)
+        if self.time_pos and self.font_time_remaining:
+            time_width = self.font_time_remaining.size('00:00')[0] + 10
+            time_height = self.font_time_remaining.get_linesize()
             self.time_rect = pg.Rect(self.time_pos[0], self.time_pos[1], time_width, time_height)
         else:
             self.time_rect = None
-        if self.time_elapsed_pos and self.fontDigi:
-            time_width = self.fontDigi.size('00:00')[0] + 10
-            time_height = self.fontDigi.get_linesize()
+        if self.time_elapsed_pos and self.font_time_elapsed:
+            time_width = self.font_time_elapsed.size('00:00')[0] + 10
+            time_height = self.font_time_elapsed.get_linesize()
             self.time_elapsed_rect = pg.Rect(self.time_elapsed_pos[0], self.time_elapsed_pos[1], time_width, time_height)
         else:
             self.time_elapsed_rect = None
-        if self.time_total_pos and self.fontDigi:
-            time_width = self.fontDigi.size('00:00')[0] + 10
-            time_height = self.fontDigi.get_linesize()
+        if self.time_total_pos and self.font_time_total:
+            time_width = self.font_time_total.size('00:00')[0] + 10
+            time_height = self.font_time_total.get_linesize()
             self.time_total_rect = pg.Rect(self.time_total_pos[0], self.time_total_pos[1], time_width, time_height)
         else:
             self.time_total_rect = None
@@ -1558,13 +1560,70 @@ class CassetteHandler:
         else:
             self.fontB = pg.font.SysFont("DejaVuSans", size_bold, bold=True)
         
-        # Digital font for time
-        digi_path = os.path.join(os.path.dirname(__file__), 'fonts', 'DSEG7Classic-Italic.ttf')
-        if os.path.exists(digi_path):
-            self.fontDigi = pg.font.Font(digi_path, size_digi)
-            log_debug(f"  Font digi: loaded {digi_path}", "verbose")
+        # Digital font for time (default; used when per-field font/size not set)
+        default_digi_path = os.path.join(os.path.dirname(__file__), 'fonts', 'DSEG7Classic-Italic.ttf')
+        if os.path.exists(default_digi_path):
+            self.fontDigi = pg.font.Font(default_digi_path, size_digi)
+            log_debug(f"  Font digi: loaded {default_digi_path}", "verbose")
         else:
             self.fontDigi = pg.font.SysFont("DejaVuSans", size_digi)
+
+        # Per-field time fonts (remaining, elapsed, total): optional font path + fontsize; fallback to fontDigi
+        meter_path = os.path.join(self.config.get(BASE_PATH), self.config.get(SCREEN_INFO)[METER_FOLDER])
+        self._time_font_cache = {}
+
+        def resolve_time_font_path(font_value):
+            if not font_value:
+                return default_digi_path
+            if os.path.isabs(font_value) and os.path.exists(font_value):
+                return font_value
+            for base in (meter_path, font_path):
+                if base:
+                    p = os.path.join(base.rstrip(os.sep), font_value.lstrip(os.sep))
+                    if os.path.exists(p):
+                        return p
+            return default_digi_path
+
+        def get_time_font(path, size):
+            if (path, size) == (default_digi_path, size_digi):
+                return self.fontDigi
+            key = (path, size)
+            if key not in self._time_font_cache:
+                if os.path.exists(path):
+                    self._time_font_cache[key] = pg.font.Font(path, size)
+                    log_debug(f"  Time font: loaded {path} size={size}", "verbose")
+                else:
+                    self._time_font_cache[key] = pg.font.SysFont("DejaVuSans", size)
+            return self._time_font_cache[key]
+
+        path_remaining = resolve_time_font_path(mc_vol.get(TIME_REMAINING_FONT))
+        size_remaining = mc_vol.get(TIME_REMAINING_FONTSIZE) or size_digi
+        path_elapsed = resolve_time_font_path(mc_vol.get(TIME_ELAPSED_FONT))
+        size_elapsed = mc_vol.get(TIME_ELAPSED_FONTSIZE) or size_digi
+        path_total = resolve_time_font_path(mc_vol.get(TIME_TOTAL_FONT))
+        size_total = mc_vol.get(TIME_TOTAL_FONTSIZE) or size_digi
+
+        self.fontDigiRemaining = get_time_font(path_remaining, size_remaining)
+        self.fontDigiElapsed = get_time_font(path_elapsed, size_elapsed)
+        self.fontDigiTotal = get_time_font(path_total, size_total)
+
+        # Effective font per time field: style from pos (x,y,style) — light/regular/bold use text font, digi or omit = digi font
+        def norm_time_style(s):
+            if not s:
+                return FONT_STYLE_R
+            s = s.strip().lower()
+            if s == "light":
+                return FONT_STYLE_L
+            if s == "bold":
+                return FONT_STYLE_B
+            return FONT_STYLE_R
+
+        style_rem = mc_vol.get(TIME_REMAINING_STYLE)
+        style_elapsed = mc_vol.get(TIME_ELAPSED_STYLE)
+        style_total = mc_vol.get(TIME_TOTAL_STYLE)
+        self.font_time_remaining = self.fontDigiRemaining if (not style_rem or style_rem == "digi") else self._font_for_style(norm_time_style(style_rem))
+        self.font_time_elapsed = self.fontDigiElapsed if (not style_elapsed or style_elapsed == "digi") else self._font_for_style(norm_time_style(style_elapsed))
+        self.font_time_total = self.fontDigiTotal if (not style_total or style_total == "digi") else self._font_for_style(norm_time_style(style_total))
     
     def _font_for_style(self, style):
         """Get font for style."""
@@ -2001,14 +2060,14 @@ class CassetteHandler:
                     else:
                         t_color = self.time_color
                     
-                    self.last_time_surf = self.fontDigi.render(time_str, True, t_color)
+                    self.last_time_surf = self.font_time_remaining.render(time_str, True, t_color)
                     self.screen.blit(self.last_time_surf, self.time_pos)
                     
                     if DEBUG_LEVEL_CURRENT == "trace" and DEBUG_TRACE.get("time", False):
                         log_debug(f"[Time] OUTPUT: rendered '{time_str}' at {self.time_pos}, color={t_color}", "trace", "time")
 
         # LAYER 7b: Elapsed time (when time.elapsed.pos set, anti-collision: force redraw when reels overlap)
-        if self.time_elapsed_pos and self.fontDigi:
+        if self.time_elapsed_pos and self.font_time_elapsed:
             seek_ms = meta.get("seek") or 0
             elapsed_sec = max(0, int(seek_ms) // 1000)
             elapsed_str = f"{elapsed_sec // 60:02d}:{elapsed_sec % 60:02d}"
@@ -2021,11 +2080,11 @@ class CassetteHandler:
                 if self.bgr_surface and self.time_elapsed_rect:
                     self.screen.blit(self.bgr_surface, self.time_elapsed_rect.topleft, self.time_elapsed_rect)
                     dirty_rects.append(self.time_elapsed_rect.copy())
-                surf = self.fontDigi.render(elapsed_str, True, self.time_elapsed_color)
+                surf = self.font_time_elapsed.render(elapsed_str, True, self.time_elapsed_color)
                 self.screen.blit(surf, self.time_elapsed_pos)
 
         # LAYER 7c: Total time (when time.total.pos set, anti-collision: force redraw when reels overlap)
-        if self.time_total_pos and self.fontDigi:
+        if self.time_total_pos and self.font_time_total:
             duration_sec = max(0, int(meta.get("duration") or 0))
             total_str = f"{duration_sec // 60:02d}:{duration_sec % 60:02d}"
             needs_redraw = (
@@ -2037,7 +2096,7 @@ class CassetteHandler:
                 if self.bgr_surface and self.time_total_rect:
                     self.screen.blit(self.bgr_surface, self.time_total_rect.topleft, self.time_total_rect)
                     dirty_rects.append(self.time_total_rect.copy())
-                surf = self.fontDigi.render(total_str, True, self.time_total_color)
+                surf = self.font_time_total.render(total_str, True, self.time_total_color)
                 self.screen.blit(surf, self.time_total_pos)
 
         # LAYER 8: Sample rate / format icon

--- a/volumio_peppymeter/volumio_configfileparser.py
+++ b/volumio_peppymeter/volumio_configfileparser.py
@@ -278,10 +278,19 @@ PLAY_SAMPLE_STYLE = "PLAY_SAMPLE_STYLE"
 PLAY_SAMPLE_MAX = "playinfo.samplerate.maxwidth"
 TIME_REMAINING_POS = "time.remaining.pos"
 TIMECOLOR = "time.remaining.color"
+TIME_REMAINING_STYLE = "time.remaining.style"
+TIME_REMAINING_FONT = "time.remaining.font"
+TIME_REMAINING_FONTSIZE = "time.remaining.fontsize"
 TIME_ELAPSED_POS = "time.elapsed.pos"
+TIME_ELAPSED_STYLE = "time.elapsed.style"
 TIME_ELAPSED_COLOR = "time.elapsed.color"
+TIME_ELAPSED_FONT = "time.elapsed.font"
+TIME_ELAPSED_FONTSIZE = "time.elapsed.fontsize"
 TIME_TOTAL_POS = "time.total.pos"
 TIME_TOTAL_COLOR = "time.total.color"
+TIME_TOTAL_STYLE = "time.total.style"
+TIME_TOTAL_FONT = "time.total.font"
+TIME_TOTAL_FONTSIZE = "time.total.fontsize"
 FONT_STYLE_B = "bold"
 FONT_STYLE_R = "regular"
 FONT_STYLE_L = "light"
@@ -1322,10 +1331,12 @@ class Volumio_ConfigFileParser(object):
             d[PLAY_SAMPLE_MAX] = None
 
         try:
-            spl = config_file.get(section, TIME_REMAINING_POS).split(',')		
+            spl = config_file.get(section, TIME_REMAINING_POS).split(',')
             d[TIME_REMAINING_POS] = (int(spl[0]), int(spl[1]))
+            d[TIME_REMAINING_STYLE] = spl[2].strip().lower() if len(spl) >= 3 else None
         except:
             d[TIME_REMAINING_POS] = None
+            d[TIME_REMAINING_STYLE] = None
         try:
             d[FONTSIZE_LIGHT] = config_file.getint(section, FONTSIZE_LIGHT)
         except:
@@ -1355,8 +1366,10 @@ class Volumio_ConfigFileParser(object):
         try:
             spl = config_file.get(section, TIME_ELAPSED_POS).split(',')
             d[TIME_ELAPSED_POS] = (int(spl[0]), int(spl[1]))
+            d[TIME_ELAPSED_STYLE] = spl[2].strip().lower() if len(spl) >= 3 else None
         except:
             d[TIME_ELAPSED_POS] = None
+            d[TIME_ELAPSED_STYLE] = None
         try:
             spl = config_file.get(section, TIME_ELAPSED_COLOR).split(',')
             d[TIME_ELAPSED_COLOR] = (int(spl[0]), int(spl[1]), int(spl[2]))
@@ -1365,13 +1378,41 @@ class Volumio_ConfigFileParser(object):
         try:
             spl = config_file.get(section, TIME_TOTAL_POS).split(',')
             d[TIME_TOTAL_POS] = (int(spl[0]), int(spl[1]))
+            d[TIME_TOTAL_STYLE] = spl[2].strip().lower() if len(spl) >= 3 else None
         except:
             d[TIME_TOTAL_POS] = None
+            d[TIME_TOTAL_STYLE] = None
         try:
             spl = config_file.get(section, TIME_TOTAL_COLOR).split(',')
             d[TIME_TOTAL_COLOR] = (int(spl[0]), int(spl[1]), int(spl[2]))
         except:
             d[TIME_TOTAL_COLOR] = (255, 255, 255)
+
+        # Per-field time font (optional; fallback to font.size.digi and default digi TTF)
+        try:
+            d[TIME_REMAINING_FONT] = config_file.get(section, TIME_REMAINING_FONT).strip() or None
+        except:
+            d[TIME_REMAINING_FONT] = None
+        try:
+            d[TIME_REMAINING_FONTSIZE] = config_file.getint(section, TIME_REMAINING_FONTSIZE)
+        except:
+            d[TIME_REMAINING_FONTSIZE] = None
+        try:
+            d[TIME_ELAPSED_FONT] = config_file.get(section, TIME_ELAPSED_FONT).strip() or None
+        except:
+            d[TIME_ELAPSED_FONT] = None
+        try:
+            d[TIME_ELAPSED_FONTSIZE] = config_file.getint(section, TIME_ELAPSED_FONTSIZE)
+        except:
+            d[TIME_ELAPSED_FONTSIZE] = None
+        try:
+            d[TIME_TOTAL_FONT] = config_file.get(section, TIME_TOTAL_FONT).strip() or None
+        except:
+            d[TIME_TOTAL_FONT] = None
+        try:
+            d[TIME_TOTAL_FONTSIZE] = config_file.getint(section, TIME_TOTAL_FONTSIZE)
+        except:
+            d[TIME_TOTAL_FONTSIZE] = None
 
         try:
             d[SPECTRUM_VISIBLE] = config_file.getboolean(section, SPECTRUM_VISIBLE)


### PR DESCRIPTION
Time fields (remaining, elapsed, total) can now take an optional **style** as the third value in `time.*.pos`, using the same pattern as `playinfo.title.pos = 416,669,bold`. No extra keys; style is part of the pos line.

## Changes

- **Parser** (`volumio_configfileparser.py`): When parsing `time.remaining.pos`, `time.elapsed.pos`, `time.total.pos`, a third comma-separated value is stored as style (lowercased). Two-value pos (`x,y`) leaves style `None`.
- **Handlers** (basic, cassette, turntable): Effective font per time field — if style is `light`, `regular`, or `bold`, use the corresponding text font; if omitted or `digi`, use the per-field digi font. Used for rect sizing and all time rendering.
