### PR TITLE
fix: spectrum init and dirty rects — pin active spectrum, merge spectrum rects into display updates

### DIFF
--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -3479,11 +3479,13 @@ class CallBack:
                     meter_name = self._get_active_meter_name()
                     if meter_name:
                         self.discovery_announcer.set_active_meter(meter_name)
-            return
+            return []
         
         # Update spectrum
         if self.spectrum_output is not None:
-            self.spectrum_output.update()
+            return self.spectrum_output.update()
+        
+        return []
     
     def _get_active_meter_name(self):
         """Get the currently active meter section name from the meter config.
@@ -4093,6 +4095,27 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
     # -------------------------------------------------------------------------
     # Main loop - OPTIMIZED with dirty rectangle updates
     # -------------------------------------------------------------------------
+    def _merge_dirty_rects(base_rects, extra_rects):
+        """Merge dirty-rect collections into a flat list."""
+        merged = []
+        
+        def _append_rects(src):
+            if not src:
+                return
+            if isinstance(src, pg.Rect):
+                merged.append(src)
+                return
+            try:
+                for r in src:
+                    if r:
+                        merged.append(r)
+            except TypeError:
+                pass
+        
+        _append_rects(base_rects)
+        _append_rects(extra_rects)
+        return merged
+    
     clock = Clock()
     pm.meter.start()
     
@@ -4217,7 +4240,8 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
         if not ov.get("enabled", False):
             # No extended config - just run meter with dirty rect updates
             meter_rects = pm.meter.run()
-            callback.peppy_meter_update()
+            spectrum_rects = callback.peppy_meter_update()
+            meter_rects = _merge_dirty_rects(meter_rects, spectrum_rects)
             # OPTIMIZATION: Use dirty rectangle update
             if meter_rects:
                 pg.display.update(meter_rects)
@@ -4266,7 +4290,8 @@ def start_display_output(pm, callback, meter_config_volumio, volumio_host='local
                     except Exception:
                         pass
                 
-                callback.peppy_meter_update()
+                spectrum_rects = callback.peppy_meter_update()
+                dirty_rects = _merge_dirty_rects(dirty_rects, spectrum_rects)
                 
                 # Display update
                 if dirty_rects:

--- a/volumio_peppymeter/volumio_spectrum.py
+++ b/volumio_peppymeter/volumio_spectrum.py
@@ -6,6 +6,7 @@
 
 import os
 import time
+import configparser
 from datetime import datetime
 from threading import Thread
 
@@ -129,6 +130,20 @@ class SpectrumOutput(Thread):
         self.util.image_util = SpectrumUtil()
      
         # get the peppy spectrum object
+        spectrum_config_path = os.path.join(self.SpectrumPath, "config.txt")
+        if os.path.exists(spectrum_config_path):
+            try:
+                sp_config = configparser.ConfigParser()
+                sp_config.read(spectrum_config_path)
+                if "current" not in sp_config:
+                    sp_config["current"] = {}
+                # Ensure Spectrum.__init__ loads only the active section.
+                sp_config["current"]["spectrum"] = self.s
+                with open(spectrum_config_path, "w") as f:
+                    sp_config.write(f)
+            except Exception as e:
+                _log_debug(f"[Spectrum] failed to update config.txt spectrum key: {e}", "verbose")
+
         os.chdir(self.SpectrumPath) # to find the config file
         self.sp = None
         self.sp = Spectrum(self.util, standalone=False)

--- a/volumio_peppymeter/volumio_spectrum.py
+++ b/volumio_peppymeter/volumio_spectrum.py
@@ -173,6 +173,8 @@ class SpectrumOutput(Thread):
         The parent (volumio_peppymeter) handles display updates.
         """
         
+        dirty_rects = []
+        
         if hasattr(self, 'sp') and self.sp is not None:
             # if background is ready
             if self.sp.components[0].content is not None:
@@ -183,10 +185,20 @@ class SpectrumOutput(Thread):
                 # Clean dirty areas and draw WITHOUT calling display.update()
                 # This prevents double display updates that cause flicker
                 if hasattr(self.sp, '_dirty_rects') and self.sp._dirty_rects:
-                    for rect in self.sp._dirty_rects:
+                    # Keep old dirty rects: draw_area() cleans previous frame regions.
+                    old_dirty = [r.copy() for r in self.sp._dirty_rects if r]
+                    for rect in old_dirty:
                         self.sp.draw_area(rect)
                     self.sp._dirty_rects = []
+                    dirty_rects.extend(old_dirty)
                 self.sp.draw()
+                
+                # Keep current dirty rects produced by draw() for parent display update.
+                if hasattr(self.sp, '_dirty_rects') and self.sp._dirty_rects:
+                    dirty_rects.extend([r.copy() for r in self.sp._dirty_rects if r])
+                elif self.util.screen_rect:
+                    # Conservative fallback: ensure spectrum region is refreshed.
+                    dirty_rects.append(self.util.screen_rect.copy())
                 
                 # Restore previous clip
                 self.util.pygame_screen.set_clip(prev_clip)
@@ -194,6 +206,8 @@ class SpectrumOutput(Thread):
                 # TRACE: Log update (only occasionally to reduce noise)
                 if _DEBUG_LEVEL == "trace" and _DEBUG_TRACE.get("spectrum", False):
                     _log_debug(f"[Spectrum] OUTPUT: draw (no display.update), clip={self.util.screen_rect}", "trace", "spectrum")
+        
+        return dirty_rects
     
     def get_current_bins(self):
         """Get current spectrum bin values for network broadcast.


### PR DESCRIPTION
Pin active spectrum in `config.txt` before creating `Spectrum()` so the constructor loads only the selected section instead of all theme sections (avoids missing-asset issues). Write `current.spectrum` in `SpectrumOutput.run()` when spectrum config exists.

Return spectrum dirty rectangles from `SpectrumOutput.update()` and `CallBack.peppy_meter_update()`, and merge them with handler/meter dirty lists in the main loop via `_merge_dirty_rects()`. Ticker and other updates no longer starve spectrum refresh; display updates include spectrum regions.