### PR TITLE
feat: headless server mode, end-of-queue fix, and remote sync stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ Stream visualization data to remote displays on your network.
 | Discovery Port | 1024-65535 | 5579 | UDP port for server discovery broadcasts |
 
 **Server modes:**
-- **Server Only**: Headless mode - streams data but shows no local display (for dedicated servers)
-- **Server + Local**: Streams data AND shows visualization locally (default)
+- **Server Only**: Headless mode - runs a dedicated non-rendering runtime (no local window/render callbacks) and streams level/spectrum/discovery data only (for dedicated servers)
+- **Server + Local**: Streams data AND shows visualization locally using the standard display/render pipeline (default)
 
 **How it works:**
 1. Server broadcasts discovery packets on UDP (default port 5579)
@@ -281,6 +281,8 @@ Stream visualization data to remote displays on your network.
 3. Audio level data streams via UDP (default port 5580)
 4. Clients fetch configuration and templates from server
 5. Metadata comes from Volumio's socket.io interface
+
+In headless mode, server shutdown closes network sockets/pipes as part of the headless loop cleanup so the next start can bind the same UDP ports cleanly.
 
 See [Remote Client](#remote-display-client) section for client installation.
 

--- a/index.js
+++ b/index.js
@@ -250,7 +250,8 @@ peppyScreensaver.prototype.onStart = function() {
         // Detect if this is a transitional state (track change, seeking, etc.)
         // volatile=true indicates Volumio is in transition between states
         var isVolatile = state.volatile === true;
-        // getEmptyState (album change) has status=stop, uri='', title='' and NO volatile key
+        // Volumio's getEmptyState() — called only at end-of-queue or when trackBlock is
+        // missing — has status=stop, empty uri/title, and no volatile field (undefined).
         var isGetEmptyState = (status === 'stop' && (state.uri || '') === '' && (state.title || '') === '');
         
         // Detect track change within same service (next/previous)
@@ -262,6 +263,11 @@ peppyScreensaver.prototype.onStart = function() {
                 clearTimeout(self.persistTimer);
                 self.persistTimer = null;
                 self.logger.info('peppy_screensaver: Persist timer cancelled - playback resumed');
+            }
+            // Cancel any pending transition grace timer - playback resumed
+            if (self.transitionGraceTimer) {
+                clearTimeout(self.transitionGraceTimer);
+                self.transitionGraceTimer = null;
             }
             // Remove persist file
             try {
@@ -299,40 +305,49 @@ peppyScreensaver.prototype.onStart = function() {
                 }
             }
         } else if (lastStateIsPlaying) {
-            // Pause or stop detected
-            // Only act on genuine pause/stop, not during volatile track transitions.
-            // state.volatile===false (explicit) = real stop; undefined = getEmptyState (album change etc)
-            // isGetEmptyState: stop with empty uri/title = transitional (album change), never treat as genuine
-            var isGenuineStop = status === 'pause' || (status === 'stop' && state.volatile === false && !isGetEmptyState);
-            if (isGenuineStop) {
-
-                // Clear screensaver start timer
+            // Pause or stop detected.
+            //
+            // Classification:
+            //   volatile===true   → volatile service transition (Spotify/Airplay handoff) → ignore
+            //   status==='pause'  → always genuine
+            //   isGetEmptyState   → end-of-queue (Volumio pushEmptyState has no volatile field,
+            //                        empty title/uri). Deterministic — always genuine.
+            //   volatile===false + metadata → track-change fall-through OR user stop.
+            //                        Indistinguishable by payload; use grace timer so a
+            //                        following 'play' (track change) can cancel the stop.
+            
+            if (isVolatile) {
+                // volatile===true: service transition, ignore completely
+            } else if (status === 'pause' || isGetEmptyState) {
+                // Pause or end-of-queue: genuine stop, act immediately
+                self.logger.info('peppy_screensaver: Genuine stop — ' + (status === 'pause' ? 'paused' : 'end of queue'));
+                
+                if (self.transitionGraceTimer) {
+                    clearTimeout(self.transitionGraceTimer);
+                    self.transitionGraceTimer = null;
+                }
+                
                 if (self.Timeout) {
                     clearInterval(self.Timeout);
                     self.Timeout = null;
                 }
                 
                 if (persistDuration > 0 && fs.existsSync(runFlag)) {
-                    // Persist mode enabled - start countdown timer
-                    // Clear any existing persist timer first (reset on repeated pause/stop)
                     if (self.persistTimer) {
                         clearTimeout(self.persistTimer);
                     }
                     
                     self.logger.info('peppy_screensaver: Starting persist timer - ' + persistDuration + 's');
                     
-                    // Write persist info for Python (duration:timestamp_ms:display_mode)
                     try {
                         fs.writeFileSync(persistFile, persistDuration + ':' + Date.now() + ':' + persistDisplay);
                     } catch(e) {}
                     
                     self.persistTimer = setTimeout(function() {
                         self.persistTimer = null;
-                        // Remove persist file
                         try {
                             if (fs.existsSync(persistFile)) fs.removeSync(persistFile);
                         } catch(e) {}
-                        // Timer expired - stop PeppyMeter
                         if (fs.existsSync(runFlag)) {
                             fs.removeSync(runFlag);
                             self.logger.info('peppy_screensaver: Persist timer expired - stopping PeppyMeter');
@@ -341,19 +356,69 @@ peppyScreensaver.prototype.onStart = function() {
                     }, persistDuration * 1000);
                     
                 } else {
-                    // Persist disabled or PeppyMeter not running - immediate stop
                     if (fs.existsSync(runFlag)) {
                         fs.removeSync(runFlag);
                     }
                     lastStateIsPlaying = false;
                 }
-            } else {
-                // Transitional state: stop with volatile=true, undefined, or getEmptyState (empty uri/title). Do not persist.
-                // Defensive: remove any stale persist file from race or older bug.
+            } else if (status === 'stop') {
+                // Stop with metadata (volatile===false or undefined, not getEmptyState).
+                // Could be track-change (play follows) or user-stop (no play follows).
+                // Use a grace timer: if play arrives it cancels; otherwise treat as genuine.
+                if (self.transitionGraceTimer) {
+                    clearTimeout(self.transitionGraceTimer);
+                }
+                
+                var TRANSITION_GRACE_MS = 5000;
+                self.logger.info('peppy_screensaver: Stop with metadata — grace timer ' + TRANSITION_GRACE_MS + 'ms');
+                
+                self.transitionGraceTimer = setTimeout(function() {
+                    self.transitionGraceTimer = null;
+                    self.logger.info('peppy_screensaver: Grace timer expired — treating as genuine stop');
+                    
+                    if (self.Timeout) {
+                        clearInterval(self.Timeout);
+                        self.Timeout = null;
+                    }
+                    
+                    if (persistDuration > 0 && fs.existsSync(runFlag)) {
+                        if (self.persistTimer) {
+                            clearTimeout(self.persistTimer);
+                        }
+                        
+                        self.logger.info('peppy_screensaver: Starting persist timer - ' + persistDuration + 's');
+                        
+                        try {
+                            fs.writeFileSync(persistFile, persistDuration + ':' + Date.now() + ':' + persistDisplay);
+                        } catch(e) {}
+                        
+                        self.persistTimer = setTimeout(function() {
+                            self.persistTimer = null;
+                            try {
+                                if (fs.existsSync(persistFile)) fs.removeSync(persistFile);
+                            } catch(e) {}
+                            if (fs.existsSync(runFlag)) {
+                                fs.removeSync(runFlag);
+                                self.logger.info('peppy_screensaver: Persist timer expired - stopping PeppyMeter');
+                            }
+                            lastStateIsPlaying = false;
+                        }, persistDuration * 1000);
+                        
+                    } else {
+                        if (fs.existsSync(runFlag)) {
+                            fs.removeSync(runFlag);
+                        }
+                        lastStateIsPlaying = false;
+                    }
+                }, TRANSITION_GRACE_MS);
+            }
+            
+            // Defensive: clear stale persist file on any transitional/volatile stop
+            if (isVolatile) {
                 try {
                     if (fs.existsSync(persistFile)) {
                         fs.removeSync(persistFile);
-                        self.logger.info(id + 'pushState: transitional stop (volatile=' + state.volatile + (isGetEmptyState ? ', getEmptyState' : '') + '), cleared persist file');
+                        self.logger.info(id + 'pushState: volatile stop, cleared persist file');
                     }
                 } catch (e) {}
             }
@@ -440,6 +505,12 @@ peppyScreensaver.prototype.onStop = function() {
         if (self.persistTimer) {
             clearTimeout(self.persistTimer);
             self.persistTimer = null;
+        }
+        
+        // clear transition grace timer
+        if (self.transitionGraceTimer) {
+            clearTimeout(self.transitionGraceTimer);
+            self.transitionGraceTimer = null;
         }
         
         // remove old flag

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -3701,6 +3701,171 @@ def stop_watcher():
 
 
 # =============================================================================
+# Headless Output Loop — server-only mode (no local display rendering)
+# =============================================================================
+def start_headless_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000):
+    """Lightweight I/O loop for server-only (headless) mode.
+    
+    Broadcasts audio level and spectrum data to remote clients without any
+    local display rendering.  Eliminates meter.run(), handler.render(), and
+    pg.display.update() — the dominant CPU consumers — while keeping all
+    remote-client services fully operational.
+    
+    :param pm: Peppymeter instance (data_source used for level data)
+    :param callback: CallBack instance (for pending_restart / active meter sync)
+    :param meter_config_volumio: Volumio meter configuration dict
+    :param volumio_host: Volumio host for socket.io metadata
+    :param volumio_port: Volumio port for socket.io
+    """
+    cfg = pm.util.meter_config
+
+    last_metadata = {
+        "artist": "", "title": "", "album": "", "albumart": "",
+        "samplerate": "", "bitdepth": "", "trackType": "", "bitrate": "",
+        "service": "", "status": "", "_time_remain": -1, "_time_update": 0
+    }
+
+    # Random meter tracking (for active_meter sync with remote clients)
+    random_mode = meter_config_volumio[METER_BKP] == "random" or "," in meter_config_volumio[METER_BKP]
+    random_title = random_mode and meter_config_volumio[RANDOM_TITLE]
+    random_interval_mode = random_mode and not random_title
+    random_interval = cfg.get(RANDOM_METER_INTERVAL, 60)
+    random_timer = 0.0
+
+    title_changed_flag = [False]
+
+    def on_title_change():
+        title_changed_flag[0] = True
+
+    metadata_watcher = MetadataWatcher(
+        last_metadata,
+        title_changed_callback=on_title_change if random_title else None,
+        volumio_host=volumio_host,
+        volumio_port=volumio_port
+    )
+    metadata_watcher.start()
+
+    # Remote servers
+    level_port = meter_config_volumio.get(REMOTE_SERVER_PORT, 5580)
+    discovery_port = meter_config_volumio.get(REMOTE_DISCOVERY_PORT, 5579)
+    spectrum_port = meter_config_volumio.get(REMOTE_SPECTRUM_PORT, 5581)
+    config_sync_interval = meter_config_volumio.get("remote.config.sync.interval", 1)
+
+    level_server = NetworkLevelServer(port=level_port, enabled=True)
+    spectrum_server = NetworkSpectrumServer(port=spectrum_port, enabled=True, read_pipe=True)
+
+    config_path = os.path.join(PeppyPath, 'config.txt')
+    discovery_announcer = DiscoveryAnnouncer(
+        discovery_port=discovery_port,
+        level_port=level_port,
+        spectrum_port=spectrum_port,
+        volumio_port=3000,
+        interval=5.0,
+        enabled=True,
+        config_path=config_path,
+        config_check_interval=float(config_sync_interval)
+    )
+    discovery_announcer.start()
+    callback.discovery_announcer = discovery_announcer
+
+    # Set initial active meter name
+    def resolve_active_meter_name():
+        names = cfg.get(METER_NAMES) or []
+        for attr in ("current_meter_name", "meter_name", "name"):
+            try:
+                v = getattr(pm.meter, attr, None)
+                if isinstance(v, str) and (not names or v in names):
+                    return v
+            except Exception:
+                pass
+        val = (cfg.get(METER) or "").strip()
+        if val:
+            first = val.split(",")[0].strip()
+            if not names or first in names:
+                return first
+        return names[0] if names else None
+
+    active_meter_name = resolve_active_meter_name()
+    if active_meter_name and discovery_announcer:
+        discovery_announcer.set_active_meter(active_meter_name)
+
+    log_debug("=== Headless server loop started ===", "basic")
+    log_debug(f"  Level server on port {level_port}", "basic")
+    log_debug(f"  Spectrum server on port {spectrum_port} (pipe mode)", "basic")
+    log_debug(f"  Discovery on port {discovery_port}", "basic")
+
+    HEADLESS_TICK_MS = 33  # ~30 Hz — sufficient for smooth level/spectrum updates
+    clock = Clock()
+    running = True
+
+    while running:
+        if not os.path.exists(PeppyRunning):
+            log_debug("runFlag removed - headless shutdown", "basic")
+            running = False
+            break
+
+        # Persist manager (remote client feature)
+        if hasattr(callback, 'persist_manager') and callback.persist_manager:
+            callback.persist_manager.check_metadata_status(last_metadata)
+
+        # Random meter: title-change mode
+        if title_changed_flag[0]:
+            title_changed_flag[0] = False
+            meter_names = cfg.get(METER_NAMES) or []
+            if len(meter_names) > 1:
+                callback.pending_restart = True
+
+        # Random meter: interval mode
+        if random_interval_mode:
+            random_timer += clock.get_time() / 1000.0
+            if random_timer >= random_interval:
+                random_timer = 0.0
+                meter_names = cfg.get(METER_NAMES) or []
+                if len(meter_names) > 1:
+                    callback.pending_restart = True
+
+        # Handle pending restart (updates Vumeter's internal meter name)
+        if callback.pending_restart:
+            callback.pending_restart = False
+            if pm.meter:
+                pm.meter.restart()
+                nm = resolve_active_meter_name()
+                if nm and nm != active_meter_name:
+                    active_meter_name = nm
+                    if discovery_announcer:
+                        discovery_announcer.set_active_meter(nm)
+
+        # Broadcast level data
+        if level_server and level_server.enabled:
+            try:
+                ds = pm.data_source
+                if ds:
+                    left = ds.get_current_left_channel_data()
+                    right = ds.get_current_right_channel_data()
+                    mono = ds.get_current_mono_channel_data()
+                    level_server.broadcast(left, right, mono)
+            except Exception:
+                pass
+
+        # Broadcast spectrum data (pipe mode — sole consumer, no contention)
+        if spectrum_server and spectrum_server.enabled:
+            spectrum_server.broadcast()
+
+        clock.tick(1000 // HEADLESS_TICK_MS)
+
+    # Cleanup
+    log_debug("=== Headless server shutting down ===", "basic")
+    if level_server:
+        level_server.stop()
+    if spectrum_server:
+        spectrum_server.stop()
+    if discovery_announcer:
+        discovery_announcer.stop()
+    metadata_watcher.stop()
+    stop_profiling()
+
+
+# =============================================================================
 # Main Display Output with Overlay - OPTIMIZED
 # =============================================================================
 def start_display_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000, check_reload_callback=None):
@@ -4592,6 +4757,14 @@ if __name__ == "__main__":
     pm.meter.malloc_trim = callback.trim_memory
     pm.malloc_trim = callback.exit_trim_memory
     
+    # Detect headless (server-only) mode — no local rendering, minimal CPU
+    remote_enabled = meter_config_volumio.get(REMOTE_SERVER_ENABLED, False)
+    remote_mode = meter_config_volumio.get(REMOTE_SERVER_MODE, "server_local")
+    is_headless = remote_enabled and remote_mode == "server"
+    
+    if is_headless:
+        log_debug("*** HEADLESS MODE (server-only) — no local display ***", "basic")
+    
     # Initialize display
     screen_w = pm.util.meter_config[SCREEN_INFO][WIDTH]
     screen_h = pm.util.meter_config[SCREEN_INFO][HEIGHT]
@@ -4608,9 +4781,17 @@ if __name__ == "__main__":
         watcher = Thread(target=stop_watcher, daemon=True)
         watcher.start()
         
-        # Initialize display with SDL2 positioning support
-        if use_sdl2:
-            # Grab screenshot to get full display dimensions
+        if is_headless:
+            # Headless: use dummy video driver — valid surfaces, no visible window.
+            # Upstream Peppymeter/Vumeter init needs a display surface, but nothing
+            # is ever rendered or pushed to a framebuffer.
+            os.environ["SDL_VIDEODRIVER"] = "dummy"
+            pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
+            pm.util.screen_copy = pm.util.PYGAME_SCREEN
+            
+            start_headless_output(pm, callback, meter_config_volumio)
+        elif use_sdl2:
+            # SDL2 positioning support
             try:
                 screenshot_img = pyscreenshot.grab()
                 display_w = screenshot_img.size[0]
@@ -4620,7 +4801,6 @@ if __name__ == "__main__":
                 display_w = screen_w
                 display_h = screen_h
             
-            # Calculate position
             if meter_config_volumio.get(POSITION_TYPE) == "center":
                 screen_x = int((display_w - screen_w) / 2)
                 screen_y = int((display_h - screen_h) / 2)
@@ -4630,11 +4810,9 @@ if __name__ == "__main__":
             
             log_debug(f"SDL2 positioning: display={display_w}x{display_h}, meter={screen_w}x{screen_h}, pos=({screen_x},{screen_y})")
             
-            # Initialize hidden display
             pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h, hide=True)
             pm.util.screen_copy = pm.util.PYGAME_SCREEN
             
-            # Position and show window
             try:
                 win = Window.from_display_module()
                 win.position = (screen_x, screen_y)
@@ -4642,13 +4820,14 @@ if __name__ == "__main__":
                 log_debug("SDL2 window positioned and shown")
             except Exception as e:
                 log_debug(f"Window positioning failed: {e}")
+            
+            start_display_output(pm, callback, meter_config_volumio)
         else:
             # Non-SDL2 fallback
             pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
             pm.util.screen_copy = pm.util.PYGAME_SCREEN
-        
-        # Run main display loop
-        start_display_output(pm, callback, meter_config_volumio)
+            
+            start_display_output(pm, callback, meter_config_volumio)
         
     except MemoryError:
         print('ERROR: Memory Exception')

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -3701,171 +3701,6 @@ def stop_watcher():
 
 
 # =============================================================================
-# Headless Output Loop — server-only mode (no local display rendering)
-# =============================================================================
-def start_headless_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000):
-    """Lightweight I/O loop for server-only (headless) mode.
-    
-    Broadcasts audio level and spectrum data to remote clients without any
-    local display rendering.  Eliminates meter.run(), handler.render(), and
-    pg.display.update() — the dominant CPU consumers — while keeping all
-    remote-client services fully operational.
-    
-    :param pm: Peppymeter instance (data_source used for level data)
-    :param callback: CallBack instance (for pending_restart / active meter sync)
-    :param meter_config_volumio: Volumio meter configuration dict
-    :param volumio_host: Volumio host for socket.io metadata
-    :param volumio_port: Volumio port for socket.io
-    """
-    cfg = pm.util.meter_config
-
-    last_metadata = {
-        "artist": "", "title": "", "album": "", "albumart": "",
-        "samplerate": "", "bitdepth": "", "trackType": "", "bitrate": "",
-        "service": "", "status": "", "_time_remain": -1, "_time_update": 0
-    }
-
-    # Random meter tracking (for active_meter sync with remote clients)
-    random_mode = meter_config_volumio[METER_BKP] == "random" or "," in meter_config_volumio[METER_BKP]
-    random_title = random_mode and meter_config_volumio[RANDOM_TITLE]
-    random_interval_mode = random_mode and not random_title
-    random_interval = cfg.get(RANDOM_METER_INTERVAL, 60)
-    random_timer = 0.0
-
-    title_changed_flag = [False]
-
-    def on_title_change():
-        title_changed_flag[0] = True
-
-    metadata_watcher = MetadataWatcher(
-        last_metadata,
-        title_changed_callback=on_title_change if random_title else None,
-        volumio_host=volumio_host,
-        volumio_port=volumio_port
-    )
-    metadata_watcher.start()
-
-    # Remote servers
-    level_port = meter_config_volumio.get(REMOTE_SERVER_PORT, 5580)
-    discovery_port = meter_config_volumio.get(REMOTE_DISCOVERY_PORT, 5579)
-    spectrum_port = meter_config_volumio.get(REMOTE_SPECTRUM_PORT, 5581)
-    config_sync_interval = meter_config_volumio.get("remote.config.sync.interval", 1)
-
-    level_server = NetworkLevelServer(port=level_port, enabled=True)
-    spectrum_server = NetworkSpectrumServer(port=spectrum_port, enabled=True, read_pipe=True)
-
-    config_path = os.path.join(PeppyPath, 'config.txt')
-    discovery_announcer = DiscoveryAnnouncer(
-        discovery_port=discovery_port,
-        level_port=level_port,
-        spectrum_port=spectrum_port,
-        volumio_port=3000,
-        interval=5.0,
-        enabled=True,
-        config_path=config_path,
-        config_check_interval=float(config_sync_interval)
-    )
-    discovery_announcer.start()
-    callback.discovery_announcer = discovery_announcer
-
-    # Set initial active meter name
-    def resolve_active_meter_name():
-        names = cfg.get(METER_NAMES) or []
-        for attr in ("current_meter_name", "meter_name", "name"):
-            try:
-                v = getattr(pm.meter, attr, None)
-                if isinstance(v, str) and (not names or v in names):
-                    return v
-            except Exception:
-                pass
-        val = (cfg.get(METER) or "").strip()
-        if val:
-            first = val.split(",")[0].strip()
-            if not names or first in names:
-                return first
-        return names[0] if names else None
-
-    active_meter_name = resolve_active_meter_name()
-    if active_meter_name and discovery_announcer:
-        discovery_announcer.set_active_meter(active_meter_name)
-
-    log_debug("=== Headless server loop started ===", "basic")
-    log_debug(f"  Level server on port {level_port}", "basic")
-    log_debug(f"  Spectrum server on port {spectrum_port} (pipe mode)", "basic")
-    log_debug(f"  Discovery on port {discovery_port}", "basic")
-
-    HEADLESS_TICK_MS = 33  # ~30 Hz — sufficient for smooth level/spectrum updates
-    clock = Clock()
-    running = True
-
-    while running:
-        if not os.path.exists(PeppyRunning):
-            log_debug("runFlag removed - headless shutdown", "basic")
-            running = False
-            break
-
-        # Persist manager (remote client feature)
-        if hasattr(callback, 'persist_manager') and callback.persist_manager:
-            callback.persist_manager.check_metadata_status(last_metadata)
-
-        # Random meter: title-change mode
-        if title_changed_flag[0]:
-            title_changed_flag[0] = False
-            meter_names = cfg.get(METER_NAMES) or []
-            if len(meter_names) > 1:
-                callback.pending_restart = True
-
-        # Random meter: interval mode
-        if random_interval_mode:
-            random_timer += clock.get_time() / 1000.0
-            if random_timer >= random_interval:
-                random_timer = 0.0
-                meter_names = cfg.get(METER_NAMES) or []
-                if len(meter_names) > 1:
-                    callback.pending_restart = True
-
-        # Handle pending restart (updates Vumeter's internal meter name)
-        if callback.pending_restart:
-            callback.pending_restart = False
-            if pm.meter:
-                pm.meter.restart()
-                nm = resolve_active_meter_name()
-                if nm and nm != active_meter_name:
-                    active_meter_name = nm
-                    if discovery_announcer:
-                        discovery_announcer.set_active_meter(nm)
-
-        # Broadcast level data
-        if level_server and level_server.enabled:
-            try:
-                ds = pm.data_source
-                if ds:
-                    left = ds.get_current_left_channel_data()
-                    right = ds.get_current_right_channel_data()
-                    mono = ds.get_current_mono_channel_data()
-                    level_server.broadcast(left, right, mono)
-            except Exception:
-                pass
-
-        # Broadcast spectrum data (pipe mode — sole consumer, no contention)
-        if spectrum_server and spectrum_server.enabled:
-            spectrum_server.broadcast()
-
-        clock.tick(1000 // HEADLESS_TICK_MS)
-
-    # Cleanup
-    log_debug("=== Headless server shutting down ===", "basic")
-    if level_server:
-        level_server.stop()
-    if spectrum_server:
-        spectrum_server.stop()
-    if discovery_announcer:
-        discovery_announcer.stop()
-    metadata_watcher.stop()
-    stop_profiling()
-
-
-# =============================================================================
 # Main Display Output with Overlay - OPTIMIZED
 # =============================================================================
 def start_display_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000, check_reload_callback=None):
@@ -4757,14 +4592,6 @@ if __name__ == "__main__":
     pm.meter.malloc_trim = callback.trim_memory
     pm.malloc_trim = callback.exit_trim_memory
     
-    # Detect headless (server-only) mode — no local rendering, minimal CPU
-    remote_enabled = meter_config_volumio.get(REMOTE_SERVER_ENABLED, False)
-    remote_mode = meter_config_volumio.get(REMOTE_SERVER_MODE, "server_local")
-    is_headless = remote_enabled and remote_mode == "server"
-    
-    if is_headless:
-        log_debug("*** HEADLESS MODE (server-only) — no local display ***", "basic")
-    
     # Initialize display
     screen_w = pm.util.meter_config[SCREEN_INFO][WIDTH]
     screen_h = pm.util.meter_config[SCREEN_INFO][HEIGHT]
@@ -4781,17 +4608,9 @@ if __name__ == "__main__":
         watcher = Thread(target=stop_watcher, daemon=True)
         watcher.start()
         
-        if is_headless:
-            # Headless: use dummy video driver — valid surfaces, no visible window.
-            # Upstream Peppymeter/Vumeter init needs a display surface, but nothing
-            # is ever rendered or pushed to a framebuffer.
-            os.environ["SDL_VIDEODRIVER"] = "dummy"
-            pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
-            pm.util.screen_copy = pm.util.PYGAME_SCREEN
-            
-            start_headless_output(pm, callback, meter_config_volumio)
-        elif use_sdl2:
-            # SDL2 positioning support
+        # Initialize display with SDL2 positioning support
+        if use_sdl2:
+            # Grab screenshot to get full display dimensions
             try:
                 screenshot_img = pyscreenshot.grab()
                 display_w = screenshot_img.size[0]
@@ -4801,6 +4620,7 @@ if __name__ == "__main__":
                 display_w = screen_w
                 display_h = screen_h
             
+            # Calculate position
             if meter_config_volumio.get(POSITION_TYPE) == "center":
                 screen_x = int((display_w - screen_w) / 2)
                 screen_y = int((display_h - screen_h) / 2)
@@ -4810,9 +4630,11 @@ if __name__ == "__main__":
             
             log_debug(f"SDL2 positioning: display={display_w}x{display_h}, meter={screen_w}x{screen_h}, pos=({screen_x},{screen_y})")
             
+            # Initialize hidden display
             pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h, hide=True)
             pm.util.screen_copy = pm.util.PYGAME_SCREEN
             
+            # Position and show window
             try:
                 win = Window.from_display_module()
                 win.position = (screen_x, screen_y)
@@ -4820,14 +4642,13 @@ if __name__ == "__main__":
                 log_debug("SDL2 window positioned and shown")
             except Exception as e:
                 log_debug(f"Window positioning failed: {e}")
-            
-            start_display_output(pm, callback, meter_config_volumio)
         else:
             # Non-SDL2 fallback
             pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
             pm.util.screen_copy = pm.util.PYGAME_SCREEN
-            
-            start_display_output(pm, callback, meter_config_volumio)
+        
+        # Run main display loop
+        start_display_output(pm, callback, meter_config_volumio)
         
     except MemoryError:
         print('ERROR: Memory Exception')

--- a/volumio_peppymeter/volumio_peppymeter.py
+++ b/volumio_peppymeter/volumio_peppymeter.py
@@ -28,6 +28,7 @@ import io
 import math
 import json
 import hashlib
+from random import choice
 import requests
 import socket
 import struct
@@ -3701,6 +3702,200 @@ def stop_watcher():
 
 
 # =============================================================================
+# Headless Helpers
+# =============================================================================
+def _resolve_headless_meter_candidates(cfg):
+    """Resolve meter candidate list from [current] meter settings."""
+    meter_names = cfg.get(METER_NAMES) or []
+    meter_value = (cfg.get(METER) or "").strip()
+
+    if not meter_names:
+        return [], meter_value
+
+    if meter_value.lower() == "random":
+        return list(meter_names), meter_value
+
+    if "," in meter_value:
+        requested = [m.strip() for m in meter_value.split(",") if m.strip()]
+        candidates = [m for m in requested if m in meter_names]
+        return (candidates or list(meter_names)), meter_value
+
+    if meter_value in meter_names:
+        return [meter_value], meter_value
+
+    return list(meter_names), meter_value
+
+
+def _pick_headless_meter(candidates, current_meter=None):
+    """Pick next meter; avoid repeating when possible."""
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+
+    pool = [m for m in candidates if m != current_meter]
+    return choice(pool or candidates)
+
+
+class HeadlessCallBack(CallBack):
+    """Headless-safe callback that forbids render-side callback entry points."""
+
+    def peppy_meter_start(self, meter):
+        raise RuntimeError("peppy_meter_start must not run in headless mode")
+
+    def peppy_meter_stop(self, meter):
+        raise RuntimeError("peppy_meter_stop must not run in headless mode")
+
+    def peppy_meter_update(self):
+        return []
+
+
+# =============================================================================
+# Headless Output
+# =============================================================================
+def start_headless_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000):
+    """
+    Headless server loop:
+    - No local display rendering
+    - Broadcast level/spectrum/discovery only
+    - Track active meter for random sync via discovery packets
+    """
+    cfg = pm.util.meter_config
+    frame_rate = max(1, int(meter_config_volumio.get(FRAME_RATE_VOLUMIO, 30)))
+    frame_delay = 1.0 / frame_rate
+
+    # Shared metadata dict - updated by MetadataWatcher via socket.io
+    last_metadata = {
+        "artist": "", "title": "", "album": "", "albumart": "",
+        "samplerate": "", "bitdepth": "", "trackType": "", "bitrate": "",
+        "service": "", "status": "", "_time_remain": -1, "_time_update": 0
+    }
+
+    random_mode = meter_config_volumio.get(METER_BKP, "random") == "random" or "," in meter_config_volumio.get(METER_BKP, "")
+    random_title = random_mode and meter_config_volumio.get(RANDOM_TITLE, False)
+    random_interval_mode = random_mode and not random_title
+    random_interval = cfg.get(RANDOM_METER_INTERVAL, 60)
+    random_timer = 0.0
+    title_changed_flag = [False]
+
+    def on_title_change():
+        title_changed_flag[0] = True
+
+    metadata_watcher = MetadataWatcher(
+        last_metadata,
+        title_changed_callback=on_title_change if random_title else None,
+        volumio_host=volumio_host,
+        volumio_port=volumio_port
+    )
+    metadata_watcher.start()
+
+    level_port = meter_config_volumio.get(REMOTE_SERVER_PORT, 5580)
+    discovery_port = meter_config_volumio.get(REMOTE_DISCOVERY_PORT, 5579)
+    spectrum_port = meter_config_volumio.get(REMOTE_SPECTRUM_PORT, 5581)
+    config_sync_interval = meter_config_volumio.get("remote.config.sync.interval", 1)
+
+    level_server = NetworkLevelServer(port=level_port, enabled=True)
+    spectrum_server = NetworkSpectrumServer(port=spectrum_port, enabled=True, read_pipe=True)
+
+    config_path = os.path.join(PeppyPath, 'config.txt')
+    discovery_announcer = DiscoveryAnnouncer(
+        discovery_port=discovery_port,
+        level_port=level_port,
+        spectrum_port=spectrum_port,
+        volumio_port=3000,
+        interval=5.0,
+        enabled=True,
+        config_path=config_path,
+        config_check_interval=float(config_sync_interval)
+    )
+    discovery_announcer.start()
+    callback.discovery_announcer = discovery_announcer
+
+    meter_candidates, _ = _resolve_headless_meter_candidates(cfg)
+    active_meter = _pick_headless_meter(meter_candidates, None)
+    if active_meter:
+        cfg[METER] = active_meter
+        discovery_announcer.set_active_meter(active_meter)
+        log_debug(f"[HEADLESS] Initial active meter: {active_meter}", "basic")
+
+    running = True
+    while running:
+        loop_started = time.time()
+
+        if not os.path.exists(PeppyRunning):
+            log_debug("[HEADLESS] runFlag removed - initiating shutdown", "basic")
+            break
+
+        # Broadcast level data
+        try:
+            ds = pm.data_source
+            if ds:
+                left = ds.get_current_left_channel_data()
+                right = ds.get_current_right_channel_data()
+                mono = ds.get_current_mono_channel_data()
+                level_server.broadcast(left, right, mono)
+        except Exception as e:
+            log_debug(f"[HEADLESS] Level broadcast error: {e}", "basic")
+
+        # Broadcast spectrum data (pipe mode only in headless)
+        spectrum_server.broadcast()
+
+        # Handle title-change random restart
+        meter_changed = False
+        if title_changed_flag[0]:
+            title_changed_flag[0] = False
+            if random_title and len(meter_candidates) > 1:
+                next_meter = _pick_headless_meter(meter_candidates, active_meter)
+                if next_meter and next_meter != active_meter:
+                    active_meter = next_meter
+                    meter_changed = True
+
+        # Handle interval-based random restart
+        if random_interval_mode and len(meter_candidates) > 1:
+            random_timer += frame_delay
+            if random_timer >= random_interval:
+                random_timer = 0.0
+                next_meter = _pick_headless_meter(meter_candidates, active_meter)
+                if next_meter and next_meter != active_meter:
+                    active_meter = next_meter
+                    meter_changed = True
+
+        if meter_changed:
+            cfg[METER] = active_meter
+            discovery_announcer.set_active_meter(active_meter)
+            log_debug(f"[HEADLESS] Active meter changed: {active_meter}", "basic")
+
+        # Persist manager parity for remote client integration
+        if hasattr(callback, 'persist_manager') and callback.persist_manager:
+            callback.persist_manager.check_metadata_status(last_metadata)
+
+        elapsed = time.time() - loop_started
+        if elapsed < frame_delay:
+            time.sleep(frame_delay - elapsed)
+
+    # Cleanup
+    log_debug("[HEADLESS] Stopping services", "verbose")
+    try:
+        metadata_watcher.stop()
+    except Exception:
+        pass
+    try:
+        level_server.stop()
+    except Exception:
+        pass
+    try:
+        spectrum_server.stop()
+    except Exception:
+        pass
+    try:
+        discovery_announcer.stop()
+    except Exception:
+        pass
+    pm.exit()
+    log_debug("[HEADLESS] Shutdown complete", "basic")
+
+
+# =============================================================================
 # Main Display Output with Overlay - OPTIMIZED
 # =============================================================================
 def start_display_output(pm, callback, meter_config_volumio, volumio_host='localhost', volumio_port=3000, check_reload_callback=None):
@@ -4584,12 +4779,19 @@ if __name__ == "__main__":
     log_debug(f"  font.path = {meter_config_volumio.get(FONT_PATH, '')}", "verbose")
     log_debug("--- End Global Config ---", "verbose")
     
+    remote_enabled = meter_config_volumio.get(REMOTE_SERVER_ENABLED, False)
+    remote_mode = meter_config_volumio.get(REMOTE_SERVER_MODE, "server_local")
+    headless_mode = remote_enabled and remote_mode == "server"
+
     # Create callback handler
-    callback = CallBack(pm.util, meter_config_volumio, pm.meter)
-    pm.meter.callback_start = callback.peppy_meter_start
-    pm.meter.callback_stop = callback.peppy_meter_stop
-    pm.dependent = callback.peppy_meter_update
-    pm.meter.malloc_trim = callback.trim_memory
+    if headless_mode:
+        callback = HeadlessCallBack(pm.util, meter_config_volumio, pm.meter)
+    else:
+        callback = CallBack(pm.util, meter_config_volumio, pm.meter)
+        pm.meter.callback_start = callback.peppy_meter_start
+        pm.meter.callback_stop = callback.peppy_meter_stop
+        pm.dependent = callback.peppy_meter_update
+        pm.meter.malloc_trim = callback.trim_memory
     pm.malloc_trim = callback.exit_trim_memory
     
     # Initialize display
@@ -4604,51 +4806,55 @@ if __name__ == "__main__":
             Path(PeppyRunning).chmod(0o0777)
         except OSError:
             pass  # chmod not needed / not supported on Windows
-        # Start stop watcher
-        watcher = Thread(target=stop_watcher, daemon=True)
-        watcher.start()
-        
-        # Initialize display with SDL2 positioning support
-        if use_sdl2:
-            # Grab screenshot to get full display dimensions
-            try:
-                screenshot_img = pyscreenshot.grab()
-                display_w = screenshot_img.size[0]
-                display_h = screenshot_img.size[1]
-            except Exception as e:
-                log_debug(f"pyscreenshot failed: {e}, using meter size")
-                display_w = screen_w
-                display_h = screen_h
-            
-            # Calculate position
-            if meter_config_volumio.get(POSITION_TYPE) == "center":
-                screen_x = int((display_w - screen_w) / 2)
-                screen_y = int((display_h - screen_h) / 2)
-            else:
-                screen_x = meter_config_volumio.get(POS_X, 0)
-                screen_y = meter_config_volumio.get(POS_Y, 0)
-            
-            log_debug(f"SDL2 positioning: display={display_w}x{display_h}, meter={screen_w}x{screen_h}, pos=({screen_x},{screen_y})")
-            
-            # Initialize hidden display
-            pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h, hide=True)
-            pm.util.screen_copy = pm.util.PYGAME_SCREEN
-            
-            # Position and show window
-            try:
-                win = Window.from_display_module()
-                win.position = (screen_x, screen_y)
-                Window.show(win)
-                log_debug("SDL2 window positioned and shown")
-            except Exception as e:
-                log_debug(f"Window positioning failed: {e}")
+        if headless_mode:
+            log_debug("Starting headless server mode", "basic")
+            start_headless_output(pm, callback, meter_config_volumio)
         else:
-            # Non-SDL2 fallback
-            pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
-            pm.util.screen_copy = pm.util.PYGAME_SCREEN
-        
-        # Run main display loop
-        start_display_output(pm, callback, meter_config_volumio)
+            # Start stop watcher
+            watcher = Thread(target=stop_watcher, daemon=True)
+            watcher.start()
+            
+            # Initialize display with SDL2 positioning support
+            if use_sdl2:
+                # Grab screenshot to get full display dimensions
+                try:
+                    screenshot_img = pyscreenshot.grab()
+                    display_w = screenshot_img.size[0]
+                    display_h = screenshot_img.size[1]
+                except Exception as e:
+                    log_debug(f"pyscreenshot failed: {e}, using meter size")
+                    display_w = screen_w
+                    display_h = screen_h
+                
+                # Calculate position
+                if meter_config_volumio.get(POSITION_TYPE) == "center":
+                    screen_x = int((display_w - screen_w) / 2)
+                    screen_y = int((display_h - screen_h) / 2)
+                else:
+                    screen_x = meter_config_volumio.get(POS_X, 0)
+                    screen_y = meter_config_volumio.get(POS_Y, 0)
+                
+                log_debug(f"SDL2 positioning: display={display_w}x{display_h}, meter={screen_w}x{screen_h}, pos=({screen_x},{screen_y})")
+                
+                # Initialize hidden display
+                pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h, hide=True)
+                pm.util.screen_copy = pm.util.PYGAME_SCREEN
+                
+                # Position and show window
+                try:
+                    win = Window.from_display_module()
+                    win.position = (screen_x, screen_y)
+                    Window.show(win)
+                    log_debug("SDL2 window positioned and shown")
+                except Exception as e:
+                    log_debug(f"Window positioning failed: {e}")
+            else:
+                # Non-SDL2 fallback
+                pm.util.PYGAME_SCREEN = init_display(pm, meter_config_volumio, screen_w, screen_h)
+                pm.util.screen_copy = pm.util.PYGAME_SCREEN
+            
+            # Run main display loop
+            start_display_output(pm, callback, meter_config_volumio)
         
     except MemoryError:
         print('ERROR: Memory Exception')


### PR DESCRIPTION
## Summary

This PR merges `experimental` into `main` after two weeks of bug fixing with no new reports.

Key updates included in this range:

- **Headless server mode** (`remote.server.mode = server`):
  - Dedicated runtime: metadata watcher, level server (5580), spectrum server (5581), discovery announcer (5579)
  - No local display: no `meter.run()`, `pg.display.update()`, or overlay rendering
  - `SDL_VIDEODRIVER=dummy` avoids visible window; spectrum pipe exclusive to `NetworkSpectrumServer` (no contention)
  - REST endpoints unchanged (`getRemoteConfig`, `getFont`, `getVinylImage`)
- **End-of-queue screensaver fix**:
  - Rework `pushState` stop handler into three tiers: volatile (ignore), pause/getEmptyState (immediate stop), stop-with-metadata (5s grace timer)
  - Fixes regression from 9bf52ab where end-of-queue left screensaver stuck on screen
- **Remote sync stability**:
  - Broadcast first `active_meter` immediately after restart
  - Deterministic fallback for `meter=random` to avoid flip-flop on remote clients
- **Docs**:
  - Clarify remote server mode runtime behavior and clean shutdown semantics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new long-running headless networking loop and changes playback state classification/timing logic, which could affect screensaver start/stop behavior and remote streaming stability if edge cases are missed.
> 
> **Overview**
> Adds a **headless remote server mode** (`remote.server.mode=server`) that skips all local rendering and instead runs a dedicated loop to stream level/spectrum data and discovery announcements, including deterministic/random meter selection with active-meter propagation and explicit shutdown cleanup.
> 
> Refactors `pushState` pause/stop handling in `index.js` to distinguish *volatile transitions*, *pause/end-of-queue empty state*, and *stop-with-metadata*, introducing a 5s grace timer that can be canceled by a subsequent `play` to prevent unintended screensaver shutdown during track changes; also ensures timers/persist files are cleaned up consistently.
> 
> Updates README to clarify the two server modes and note that headless shutdown closes sockets/pipes so ports can be rebound cleanly on restart.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b648f2b3c1876662a3bfd860315812ea2070fe98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->