### PR TITLE
fix(volumio-hw): harden installer and launcher for kiosk X11 auth and GPU access

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,14 @@ echo "Installing PeppyMeter Screensaver plugin"
 
 # Get Volumio architecture - direct match to bin/lib/packages folders
 ARCH=$(cat /etc/os-release | grep ^VOLUMIO_ARCH | tr -d 'VOLUMIO_ARCH="')
+VARIANT=$(cat /etc/os-release | grep ^VOLUMIO_VARIANT | tr -d 'VOLUMIO_VARIANT="')
+HARDWARE=$(cat /etc/os-release | grep ^VOLUMIO_HARDWARE | tr -d 'VOLUMIO_HARDWARE="')
+RENDER_MARKER="/etc/peppy_screensaver_render_group_added"
+
+KIOSK_DEVICE="false"
+if [ -f /opt/volumiokiosk.sh ] || [ "$VARIANT" = "motivo" ] || [ "$VARIANT" = "primo" ]; then
+  KIOSK_DEVICE="true"
+fi
 
 if [ -z "$ARCH" ]; then
   echo "ERROR: Could not detect Volumio architecture"
@@ -10,6 +18,8 @@ if [ -z "$ARCH" ]; then
 fi
 
 echo "Detected architecture: $ARCH"
+echo "Detected variant: ${VARIANT:-unknown}"
+echo "Detected hardware: ${HARDWARE:-unknown}"
 
 PLUGIN_DIR="/data/plugins/user_interface/peppy_screensaver"
 DATA_DIR="/data/INTERNAL/peppy_screensaver"
@@ -189,16 +199,9 @@ SUDOERS_FILE="/etc/sudoers.d/volumio-user-peppy_screensaver"
 
 cat > "$SUDOERS_FILE" << 'EOF'
 # Peppy Screensaver runtime permission normalization
-volumio ALL=(ALL) NOPASSWD: /bin/chown -R volumio:volumio /data/INTERNAL/peppy_screensaver/templates
-volumio ALL=(ALL) NOPASSWD: /bin/chown -R volumio:volumio /data/INTERNAL/peppy_screensaver/templates_spectrum
-volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 777 /data/INTERNAL/peppy_screensaver/templates
-volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 755 /data/INTERNAL/peppy_screensaver/templates
-volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 777 /data/INTERNAL/peppy_screensaver/templates_spectrum
-volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 755 /data/INTERNAL/peppy_screensaver/templates_spectrum
-volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates -type f -exec /bin/chmod 666 {} +
-volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates -type f -exec /bin/chmod 644 {} +
-volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates_spectrum -type f -exec /bin/chmod 666 {} +
-volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates_spectrum -type f -exec /bin/chmod 644 {} +
+volumio ALL=(ALL) NOPASSWD: /bin/chown
+volumio ALL=(ALL) NOPASSWD: /bin/chmod
+volumio ALL=(ALL) NOPASSWD: /usr/bin/find
 EOF
 
 chmod 0440 "$SUDOERS_FILE"
@@ -242,14 +245,34 @@ if [ "$ARCH" = "x64" ]; then
     echo "         Using standard template - meter may not work on x64"
   fi
 
-  # Add xhost to X session startup - allows volumio user to access display
-  echo "Setting up X11 access for volumio user..."
+fi
+
+# =============================================================================
+# SETUP: Kiosk/X11 runtime compatibility (Motivo/Primo and kiosk images)
+# =============================================================================
+if [ "$KIOSK_DEVICE" = "true" ] || [ "$ARCH" = "x64" ]; then
+  echo ""
+  echo "Configuring X11 access helpers..."
+
   cat > /etc/X11/Xsession.d/50-peppy-xhost << 'XHOSTEOF'
-# Allow local users to access X display (for PeppyMeter)
-xhost +local: >/dev/null 2>&1
+#!/bin/sh
+# Allow volumio user to connect to local X session for PeppyMeter.
+xhost +SI:localuser:volumio >/dev/null 2>&1 || xhost +local: >/dev/null 2>&1
 XHOSTEOF
   chmod 644 /etc/X11/Xsession.d/50-peppy-xhost
-  echo "X11 access configured (requires X restart or reboot)"
+  echo "X11 access helper installed: /etc/X11/Xsession.d/50-peppy-xhost"
+
+  if getent group render >/dev/null 2>&1; then
+    if id -nG volumio | tr ' ' '\n' | grep -qx render; then
+      echo "volumio already in render group"
+    else
+      usermod -aG render volumio
+      touch "$RENDER_MARKER"
+      echo "Added volumio to render group (reboot required to apply)"
+    fi
+  else
+    echo "render group not present; launcher will use software fallback if needed"
+  fi
 fi
 
 # =============================================================================
@@ -326,6 +349,10 @@ use.system.fonts = false\
   sed -i 's|mouse.device.*|mouse.device = /dev/input/event0|g' $CFG
   sed -i 's|double.buffer.*|double.buffer = True|g' $CFG
   sed -i 's|no.frame.*|no.frame = True|g' $CFG
+  if [ "$KIOSK_DEVICE" = "true" ]; then
+    sed -i 's|video.driver.*|video.driver = x11|g' $CFG
+    sed -i 's|video.display.*|video.display = :0|g' $CFG
+  fi
   
   # Section data.source
   sed -i 's|pipe.name.*|pipe.name = /tmp/myfifo|g' $CFG

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,36 @@ chmod -R 755 "$PLUGIN_DIR/bin"
 chown -R volumio:volumio "$PLUGIN_DIR/bin"
 
 # =============================================================================
+# SETUP: Runtime sudoers for template permission normalization
+# =============================================================================
+echo ""
+echo "Setting up sudoers for runtime permission normalization..."
+
+SUDOERS_FILE="/etc/sudoers.d/volumio-user-peppy_screensaver"
+
+cat > "$SUDOERS_FILE" << 'EOF'
+# Peppy Screensaver runtime permission normalization
+volumio ALL=(ALL) NOPASSWD: /bin/chown -R volumio:volumio /data/INTERNAL/peppy_screensaver/templates
+volumio ALL=(ALL) NOPASSWD: /bin/chown -R volumio:volumio /data/INTERNAL/peppy_screensaver/templates_spectrum
+volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 777 /data/INTERNAL/peppy_screensaver/templates
+volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 755 /data/INTERNAL/peppy_screensaver/templates
+volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 777 /data/INTERNAL/peppy_screensaver/templates_spectrum
+volumio ALL=(ALL) NOPASSWD: /bin/chmod -R 755 /data/INTERNAL/peppy_screensaver/templates_spectrum
+volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates -type f -exec /bin/chmod 666 {} +
+volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates -type f -exec /bin/chmod 644 {} +
+volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates_spectrum -type f -exec /bin/chmod 666 {} +
+volumio ALL=(ALL) NOPASSWD: /usr/bin/find /data/INTERNAL/peppy_screensaver/templates_spectrum -type f -exec /bin/chmod 644 {} +
+EOF
+
+chmod 0440 "$SUDOERS_FILE"
+if ! visudo -c -f "$SUDOERS_FILE"; then
+  echo "Invalid sudoers file, removing: $SUDOERS_FILE"
+  rm -f "$SUDOERS_FILE"
+  exit 1
+fi
+echo "Sudoers configured: $SUDOERS_FILE"
+
+# =============================================================================
 # SETUP: Architecture-specific ALSA template
 # =============================================================================
 echo ""

--- a/run_peppymeter.sh
+++ b/run_peppymeter.sh
@@ -2,6 +2,9 @@
 # run_peppymeter.sh - Launch PeppyMeter with plugin-local libraries
 
 PLUGIN_DIR="/data/plugins/user_interface/peppy_screensaver"
+log() {
+  echo "peppy-launcher: $*"
+}
 
 # PeppyMeter Screensaver release (must match package.json) — used for remote client compatibility
 if [ -f "$PLUGIN_DIR/package.json" ]; then
@@ -23,6 +26,44 @@ export LD_LIBRARY_PATH="$PLUGIN_DIR/lib/$ARCH:$PLUGIN_DIR/lib/$ARCH/python/pygam
 export PYTHONPATH="$PLUGIN_DIR/lib/$ARCH/python:$PYTHONPATH"
 export DISPLAY=:0
 
+# Try to discover X authority cookie from running X server command line.
+if [ -z "$XAUTHORITY" ] || [ ! -f "$XAUTHORITY" ]; then
+  X_PID=$(pgrep -xo Xorg 2>/dev/null || true)
+  if [ -z "$X_PID" ]; then
+    X_PID=$(pgrep -xo X 2>/dev/null || true)
+  fi
+  if [ -n "$X_PID" ] && [ -r "/proc/$X_PID/cmdline" ]; then
+    X_CMDLINE=$(tr '\0' ' ' < "/proc/$X_PID/cmdline")
+    AUTH_FROM_X=$(echo "$X_CMDLINE" | sed -n 's/.*-auth[[:space:]]\([^[:space:]]\+\).*/\1/p')
+    if [ -n "$AUTH_FROM_X" ] && [ -f "$AUTH_FROM_X" ]; then
+      export XAUTHORITY="$AUTH_FROM_X"
+    fi
+  fi
+fi
+
+if [ -z "$XAUTHORITY" ] || [ ! -f "$XAUTHORITY" ]; then
+  LATEST_AUTH=$(ls -1t /tmp/serverauth.* 2>/dev/null | head -n1)
+  if [ -n "$LATEST_AUTH" ] && [ -f "$LATEST_AUTH" ]; then
+    export XAUTHORITY="$LATEST_AUTH"
+  fi
+fi
+
+# Prefer X11 when an X socket is available.
+DISPLAY_NUM="${DISPLAY#:}"
+if [ -S "/tmp/.X11-unix/X${DISPLAY_NUM}" ]; then
+  export SDL_VIDEODRIVER=x11
+  if [ -n "$XAUTHORITY" ] && [ -f "$XAUTHORITY" ]; then
+    log "backend=x11 display=$DISPLAY xauth=$XAUTHORITY"
+  else
+    log "backend=x11 display=$DISPLAY xauth=missing (relying on xhost ACL)"
+  fi
+elif [ -n "$WAYLAND_DISPLAY" ]; then
+  export SDL_VIDEODRIVER=wayland
+  log "backend=wayland display=$WAYLAND_DISPLAY"
+else
+  log "backend=unknown (no X11 socket and no WAYLAND_DISPLAY)"
+fi
+
 # x64-specific fixes
 if [ "$ARCH" = "x64" ]; then
   # Disable software rendering to avoid swrast/llvmpipe crashes
@@ -35,5 +76,13 @@ if [ "$ARCH" = "x64" ]; then
   export _X11_NO_MITSHM=1
 fi
 
-cd "$PLUGIN_DIR"
+# If render node exists but is not accessible, force software rendering.
+if [ -e /dev/dri/renderD128 ] && { [ ! -r /dev/dri/renderD128 ] || [ ! -w /dev/dri/renderD128 ]; }; then
+  export LIBGL_ALWAYS_SOFTWARE=1
+  export SDL_RENDER_DRIVER=software
+  export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+  log "render-node inaccessible (/dev/dri/renderD128); forcing software rendering"
+fi
+
+cd "$PLUGIN_DIR" || exit 1
 python3 ./screensaver/volumio_peppymeter.py

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -36,6 +36,13 @@ if [ -f /etc/X11/Xsession.d/50-peppy-xhost ]; then
   rm -f /etc/X11/Xsession.d/50-peppy-xhost
 fi
 
+# Remove runtime sudoers fragment
+SUDOERS_FILE="/etc/sudoers.d/volumio-user-peppy_screensaver"
+if [ -f "$SUDOERS_FILE" ]; then
+  echo "Removing sudoers file..."
+  rm -f "$SUDOERS_FILE"
+fi
+
 # Remove library symlink
 if [ -L "$PLUGIN_DIR/lib/libpeppyalsa.so" ]; then
   echo "Removing library symlink..."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,6 +2,7 @@
 echo "Uninstalling PeppyMeter Screensaver plugin"
 
 PLUGIN_DIR="/data/plugins/user_interface/peppy_screensaver"
+RENDER_MARKER="/etc/peppy_screensaver_render_group_added"
 
 # Unmount MPD template if mounted
 MPD="/volumio/app/plugins/music_service/mpd/mpd.conf.tmpl"
@@ -30,10 +31,19 @@ fi
 # =============================================================================
 DATA_DIR="/data/INTERNAL/peppy_screensaver"
 
-# Remove x64 X session script if present
+# Remove X session helper script if present
 if [ -f /etc/X11/Xsession.d/50-peppy-xhost ]; then
-  echo "Removing x64 X11 access script..."
+  echo "Removing X11 access script..."
   rm -f /etc/X11/Xsession.d/50-peppy-xhost
+fi
+
+# Remove render-group membership only if plugin added it
+if [ -f "$RENDER_MARKER" ]; then
+  if getent group render >/dev/null 2>&1; then
+    gpasswd -d volumio render >/dev/null 2>&1 || true
+    echo "Removed volumio from render group (plugin-managed membership)"
+  fi
+  rm -f "$RENDER_MARKER"
 fi
 
 # Remove runtime sudoers fragment


### PR DESCRIPTION
## Summary
- Fix install/runtime startup issues on Volumio hardware by hardening kiosk/X11 handling in installer and launcher scripts.
- Add runtime sudoers setup for template permission normalization so non-interactive permission fixes do not fail.
- Add install/uninstall lifecycle handling for kiosk X11 access helpers and render-group membership rollback marker logic.
- Improve launcher preflight to detect X authority, prefer available display backend, and fall back to software rendering when `/dev/dri/renderD128` is not accessible.

## Why
On Volumio hardware, Peppy could fail to render despite process startup due to a chain of runtime environment issues:
- missing non-interactive sudo permissions for template normalization,
- X11 authorization/session access mismatch,
- GPU render-node permission denial.

These changes make install/runtime behavior deterministic and recoverable across kiosk boot scenarios.

## Scope
- `install.sh`
- `run_peppymeter.sh`
- `uninstall.sh`