### PR TITLE
release: merge experimental into main (v3.4.1)

### DIFF
--- a/UIConfig.json
+++ b/UIConfig.json
@@ -28,6 +28,7 @@
                                       "smoothBuffer",
                                       "needleCache",
                                       "cachesize",
+                                      "meterGain",
                                       "mouseEnabled",
                                       "displayOutput",
                                       "doNotDeleteThemes",
@@ -213,6 +214,20 @@
                                              {"max": 99}
                                            ],
                              "value": 20
+                            },
+                            {
+                             "id": "meterGain",
+                             "element": "input",
+                             "type": "number",
+                             "doc": "TRANSLATE.PEPPY_SCREENSAVER.METER_SENSITIVITY_DOC",
+                             "label": "TRANSLATE.PEPPY_SCREENSAVER.METER_SENSITIVITY",
+                             "attributes": [
+                                             {"placeholder": 0},
+                                             {"maxlength": 2},
+                                             {"min": 0},
+                                             {"max": 12}
+                                           ],
+                             "value": 0
                             },
                             {
                              "id": "mouseEnabled",

--- a/i18n/strings_de.json
+++ b/i18n/strings_de.json
@@ -64,6 +64,8 @@
     "ACTIVE_FOLDER_DOC":"Auswahl des aktiv verwendeten Ordners für VU-Meter in Abhängigkeit der Bildschirmauflösung",
     "SMOOTH_BUFFER":"Zeigerträgheit",
     "SMOOTH_BUFFER_DOC":"Steuerung der Zeigerträgheit von 2...15 (2-flink ... 15-träge)",
+    "METER_SENSITIVITY":"Meter-Empfindlichkeit (dB)",
+    "METER_SENSITIVITY_DOC":"Hebt den Zeigerausschlag bei leisen Aufnahmen an. Nuetzlich fuer ReplayGain-normalisierte Bibliotheken, die deutlich unter Vollausschlag liegen, sodass die Zeiger sonst kaum ausschlagen.<br /><br /><b>Standard: 0 dB</b> (keine Aenderung)<br /><br />Wird als relative Verstaerkung nur auf die Meter-Pegel angewendet. Aendert weder die Wiedergabelautstaerke noch das Audiosignal.<br /><br />Bereich: 0 bis +12 dB. Eine Bibliothek mit Spitzen um -9 dBFS erreicht bei etwa +9 dB Vollausschlag. Pegel oberhalb des Vollausschlags werden begrenzt, sodass der Zeiger bei den lautesten Passagen einfach am Maximum anliegt.",
     "MOUSE":"Maus Unterstützung",
     "MOUSE_DOC":"Für Touch-Displays schalten sie diese Funktion ein, um die Möglichkeit zuhaben, den Screensaver per Touch zu benden. Für Standard HDMI-Displays ohne Touch-Funktion schalten Sie diese Funktion aus",
     "DISPLAY_OUTPUT_DOC":"Per default wird display port 0 verwendet auf einem raspberry pi für beide hdmi ports. Bei Volumio Primo wird allerdings display port 1 verwendet", 

--- a/i18n/strings_en.json
+++ b/i18n/strings_en.json
@@ -64,6 +64,8 @@
     "ACTIVE_FOLDER_DOC":"Selection of the actively used folder for VU-Meter depend on screen resolution",
     "SMOOTH_BUFFER":"Smooth Needle",
     "SMOOTH_BUFFER_DOC":"Set the indolence of needles: 2...15 (2-quick ... 15-lazy)",
+    "METER_SENSITIVITY":"Meter sensitivity (dB)",
+    "METER_SENSITIVITY_DOC":"Boost meter deflection for quiet recordings. Useful for ReplayGain-normalised libraries that peak well below full scale, where needles otherwise barely move.<br /><br /><b>Default: 0 dB</b> (no change)<br /><br />Applied as a relative gain to the meter levels only. It does not change playback volume or the audio in any way.<br /><br />Range: 0 to +12 dB. A library peaking near -9 dBFS reaches full scale at about +9 dB. Levels that would exceed full scale are clamped, so the needle simply rests at maximum on the loudest passages.",
     "MOUSE":"Mouse support",
     "MOUSE_DOC":"For a touchscreen enable the mouse support, to have the possibility to stop the screensaver per touch. For a standard HDMI display without touch disable this option",
     "DISPLAY_OUTPUT_DOC":"Per default is display port 0 used on a raspberry pi for both hdmi ports. Volumio Primo use display port 1", 

--- a/i18n/strings_fr.json
+++ b/i18n/strings_fr.json
@@ -64,6 +64,8 @@
     "ACTIVE_FOLDER_DOC":"La sélection du dossier activement utilisé pour le VU-Meter dépend de la résolution de l'écran",
     "SMOOTH_BUFFER":"Aiguille lisse",
     "SMOOTH_BUFFER_DOC":"Réglez l'indolence des aiguilles: 2...15 (2-rapide ... 15-paresseux)",
+    "METER_SENSITIVITY":"Sensibilite du metre (dB)",
+    "METER_SENSITIVITY_DOC":"Augmente la deviation des aiguilles pour les enregistrements peu eleves. Utile pour les bibliotheques normalisees en ReplayGain dont les pics restent bien en dessous du plein niveau, ou les aiguilles bougent autrement a peine.<br /><br /><b>Par defaut: 0 dB</b> (aucun changement)<br /><br />Applique comme un gain relatif uniquement aux niveaux des metres. Ne change ni le volume de lecture ni le signal audio.<br /><br />Plage: 0 a +12 dB. Une bibliotheque culminant autour de -9 dBFS atteint le plein niveau vers +9 dB. Les niveaux qui depasseraient le plein niveau sont limites, de sorte que l'aiguille repose simplement au maximum lors des passages les plus forts.",
     "MOUSE":"Prise en charge de la souris",
     "MOUSE_DOC":"Pour un écran tactile, activez le support de la souris, pour avoir la possibilité d'arrêter l'économiseur d'écran par touche. Pour un écran HDMI standard sans toucher, désactivez cette option",
     "DISPLAY_OUTPUT_DOC":"Par défaut, le port d'affichage 0 est utilisé sur un Raspberry Pi pour les deux ports HDMI. Volumio Primo utilise le port d'affichage 1", 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const BackupManifestName = 'manifest.json';
 const PeppyConfBackupName = 'peppymeter_config.txt';
 const SpectrumConfBackupName = 'spectrum_config.txt';
 
-var minmax = new Array(14);
+var minmax = new Array(16);
 var last_outputdevice, last_softmixer;
 var peppy_config, base_folder_P;
 
@@ -727,26 +727,32 @@ peppyScreensaver.prototype.getUIConfig = function() {
                     uiconf.sections[0].content[13].attributes[3].max,
                     uiconf.sections[0].content[13].attributes[0].placeholder];
             }
+
+            // meter sensitivity
+            uiconf.sections[0].content[14].value = parseInt(peppy_config.data.source['volume.gain.db'], 10) || 0;
+            minmax[15] = [uiconf.sections[0].content[14].attributes[2].min,
+                uiconf.sections[0].content[14].attributes[3].max,
+                uiconf.sections[0].content[14].attributes[0].placeholder];
             
             // mouse support
             var mouseSupport = (peppy_config.sdl.env['mouse.enabled']).toLowerCase() == 'true' ? true : false;
-            uiconf.sections[0].content[14].value = mouseSupport;
+            uiconf.sections[0].content[15].value = mouseSupport;
 
             // display output
-            uiconf.sections[0].content[15].value.value = self.config.get('displayOutput');
-            uiconf.sections[0].content[15].value.label = 'Display=' + self.config.get('displayOutput');
-            uiconf.sections[0].content[16].value = self.config.get('doNotDeleteThemes') === true;
+            uiconf.sections[0].content[16].value.value = self.config.get('displayOutput');
+            uiconf.sections[0].content[16].value.label = 'Display=' + self.config.get('displayOutput');
+            uiconf.sections[0].content[17].value = self.config.get('doNotDeleteThemes') === true;
 
             // use system fonts (from config.txt, default false = use PeppyFont)
             var useSystemFonts = false;
             try {
                 useSystemFonts = (peppy_config.current['use.system.fonts'] || '').toLowerCase() === 'true';
             } catch (e) {}
-            uiconf.sections[0].content[17].value = useSystemFonts;
+            uiconf.sections[0].content[18].value = useSystemFonts;
 
             // SMB share access (from config.json, default false)
             var smbEnabled = self.config.get('smbShareAccess') === true;
-            uiconf.sections[0].content[18].value = smbEnabled;
+            uiconf.sections[0].content[19].value = smbEnabled;
             
             // Normalize template permissions on settings page access
             // Reclaims ownership from SMB-created files (nobody:nogroup -> volumio:volumio)
@@ -1336,6 +1342,20 @@ peppyScreensaver.prototype.savePeppyMeterConf = function (confData) {
         confData.smoothBuffer = self.minmax('SMOOTH_BUFFER', confData.smoothBuffer, minmax[3]);
         if (peppy_config.data.source['smooth.buffer.size'] != confData.smoothBuffer) {
             peppy_config.data.source['smooth.buffer.size'] = confData.smoothBuffer;
+            noChanges = false;
+        }
+    }
+
+    // write meter sensitivity (gain in dB, consumed by the data source)
+    if (Number.isNaN(parseInt(confData.meterGain, 10)) || !isFinite(confData.meterGain)) {
+        uiNeedsUpdate = true;
+        setTimeout(function () {
+            self.commandRouter.pushToastMessage('error', self.commandRouter.getI18nString('PEPPY_SCREENSAVER.PLUGIN_NAME'), self.commandRouter.getI18nString('PEPPY_SCREENSAVER.METER_SENSITIVITY') + self.commandRouter.getI18nString('PEPPY_SCREENSAVER.NAN'));
+        }, 500);
+    } else {
+        confData.meterGain = self.minmax('METER_SENSITIVITY', confData.meterGain, minmax[15]);
+        if (peppy_config.data.source['volume.gain.db'] != confData.meterGain) {
+            peppy_config.data.source['volume.gain.db'] = confData.meterGain;
             noChanges = false;
         }
     }

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,12 @@ if [ ! -d "$PEPPYMETER_DIR" ]; then
   mkdir -p "$PLUGIN_DIR/screensaver"
   git clone --depth 1 https://github.com/foonerd/PeppyMeter.git "$PEPPYMETER_DIR"
 else
-  echo "PeppyMeter already installed"
+  echo "PeppyMeter already installed - refreshing engine modules"
+  if [ -d "$PEPPYMETER_DIR/.git" ]; then
+    git -C "$PEPPYMETER_DIR" fetch --depth 1 origin 2>/dev/null || true
+    # Update only the engine modules; leave config.txt and template folders untouched.
+    git -C "$PEPPYMETER_DIR" checkout FETCH_HEAD -- datasource.py configfileparser.py 2>/dev/null || true
+  fi
 fi
 
 # =============================================================================
@@ -357,6 +362,9 @@ use.system.fonts = false\
   # Section data.source
   sed -i 's|pipe.name.*|pipe.name = /tmp/myfifo|g' $CFG
   sed -i 's|smooth.buffer.size.*|smooth.buffer.size = 8|g' $CFG
+  if ! grep -q '^volume.gain.db' $CFG; then
+    sed -i '/^volume.max.in.pipe/a\volume.gain.db = 0' $CFG
+  fi
 fi
 
 # =============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peppy_screensaver",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "PeppyMeter screensaver for Volumio",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
       "amd64"
     ],
     "details": "VU meter screensaver using PeppyMeter",
-    "changelog": "3.4.0 Continuity Engine - backup and restore plugin settings across reinstalls; 3.3.2 - Multi-client remote (unicast discovery/level/spectrum); theme-follow reload fix; 3.3.1 peppy_fonts defaults and config toggle."
+    "changelog": "3.4.1 Meter sensitivity (dB) control with engine gain path and upgrade-safe refresh; 3.4.0 Continuity Engine - backup and restore plugin settings across reinstalls; 3.3.2 - Multi-client remote (unicast discovery/level/spectrum); theme-follow reload fix; 3.3.1 peppy_fonts defaults and config toggle."
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
## Summary
- roll up recent `experimental` work into `main`, including remote server reliability fixes, continuity-engine backup/restore, and UI/indicator hardening
- add global Meter sensitivity (dB) control with parser/data-source/install integration for ReplayGain-normalized libraries
- bump plugin release metadata to `3.4.1`

## Test plan
- [x] Local smoke test confirms meter sensitivity gain works as expected
- [x] Settings load/save and install upgrade paths validated in development
- [x] Validate clean install/upgrade path on target devices from `main`